### PR TITLE
updated set_required_attempts

### DIFF
--- a/service/counter.rb
+++ b/service/counter.rb
@@ -12,10 +12,8 @@ module Service
     end
 
     def set_required_attempts(attempts)
-      attempts = attempts&.to_i
-
-      if !attempts&.nil? && attempts&.between?(1, 10)
-        @required_attempts = attempts
+      if !attempts&.to_i&.nil? && attempts&.to_i&.between?(1, 10)
+        @required_attempts = attempts&.to_i
       else
         @required_attempts
       end


### PR DESCRIPTION
This pull request includes a change to the `service/counter.rb` file to simplify and improve the `set_required_attempts` method. The most important change involves consolidating the conversion and validation of the `attempts` parameter to ensure it is properly handled.

Simplification and improvement:

* [`service/counter.rb`](diffhunk://#diff-e2abbf315b00c40e59439fa7d607d794bf46e0e4305e7c0b3b6566d72193dcbbL15-R16): Modified the `set_required_attempts` method to combine the conversion of `attempts` to an integer and its validation into a single conditional statement, ensuring `@required_attempts` is set only when `attempts` is between 1 and 10.