### PR TITLE
Cleaned up security warnings

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,11 @@ on:
 
 jobs:
   build:
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      security-events: read
     runs-on: ubuntu-latest
     steps:
       -
@@ -18,7 +23,7 @@ jobs:
       - 
         name: Get most recent tag
         id: most_recent_tag
-        uses: oprypin/find-latest-tag@v1
+        uses: oprypin/find-latest-tag@dd2729fe78b0bb55523ae2b2a310c6773a652bd1 # v1.1.2
         with:
           repository: ${{ github.repository }}
           releases-only: false
@@ -26,13 +31,13 @@ jobs:
           prefix: 'v'
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       -
         name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -40,7 +45,7 @@ jobs:
       -
         name: Build and push to non-main
         if: github.event.pull_request.base.ref != 'main'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         env:
             VERSION: ${{ steps.most_recent_tag.outputs.tag }}
         with:
@@ -51,7 +56,7 @@ jobs:
       -
         name: Build and push to main
         if: github.event.pull_request.base.ref == 'main'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         env:
             VERSION: ${{ steps.most_recent_tag.outputs.tag }}
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,15 @@
 source 'https://rubygems.org'
 
 gem 'faraday', '~> 2.12', '>= 2.12.2'
-gem 'grape', '~> 2.2'
-gem 'json', '~> 2.9', '>= 2.9.1'
-gem 'logger', '~> 1.6', '>= 1.6.5'
+gem 'grape', '~> 2.3'
+gem 'json', '~> 2.10', '>= 2.10.1'
+gem 'logger', '~> 1.6', '>= 1.6.6'
 gem 'open3', '~> 0.2.1'
 gem 'puma', '~> 6.6'
+gem 'rack', '~> 3.1', '>= 3.1.10'
 gem 'rackup', '~> 2.2', '>= 2.2.1'
 gem 'rspec', '~> 3.13'
-gem 'rubocop', '~> 1.71', '>= 1.71.1', require: false
+gem 'rubocop', '~> 1.71', '>= 1.71.2', require: false
 gem 'sinatra', '~> 4.1', '>= 4.1.1'
 gem 'sqlite3', '~> 2.5'
 gem 'sucker_punch', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    grape (2.2.0)
+    grape (2.3.0)
       activesupport (>= 6)
       dry-types (>= 1.1)
       mustermann-grape (~> 1.1.0)
@@ -53,9 +53,9 @@ GEM
       zeitwerk
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.9.1)
+    json (2.10.1)
     language_server-protocol (3.17.0.3)
-    logger (1.6.5)
+    logger (1.6.6)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     mustermann (3.0.3)
@@ -73,7 +73,7 @@ GEM
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.8)
+    rack (3.1.10)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -98,7 +98,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    rubocop (1.71.1)
+    rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -140,14 +140,15 @@ PLATFORMS
 
 DEPENDENCIES
   faraday (~> 2.12, >= 2.12.2)
-  grape (~> 2.2)
-  json (~> 2.9, >= 2.9.1)
-  logger (~> 1.6, >= 1.6.5)
+  grape (~> 2.3)
+  json (~> 2.10, >= 2.10.1)
+  logger (~> 1.6, >= 1.6.6)
   open3 (~> 0.2.1)
   puma (~> 6.6)
+  rack (~> 3.1, >= 3.1.10)
   rackup (~> 2.2, >= 2.2.1)
   rspec (~> 3.13)
-  rubocop (~> 1.71, >= 1.71.1)
+  rubocop (~> 1.71, >= 1.71.2)
   sinatra (~> 4.1, >= 4.1.1)
   sqlite3 (~> 2.5)
   sucker_punch (~> 3.2)
@@ -169,11 +170,11 @@ CHECKSUMS
   dry-types (1.8.0) sha256=bdf444e0d2ff83f500271c7d38cb29690c2654fa78e588f68349a7b1e7341131
   faraday (2.12.2) sha256=157339c25c7b8bcb739f5cf1207cb0cefe8fa1c65027266bcbc34c90c84b9ad6
   faraday-net_http (3.4.0) sha256=a1f1e4cd6a2cf21599c8221595e27582d9936819977bbd4089a601f24c64e54a
-  grape (2.2.0) sha256=42fef93c4865b077a09db05ac0372d4e3ded3143cb1026c1323b7bfa3098f6ee
+  grape (2.3.0) sha256=99484ae2907b06a9e109edf2911c383809bf7f7c00d65554e4d01f0388728bda
   i18n (1.14.6) sha256=dc229a74f5d181f09942dd60ab5d6e667f7392c4ee826f35096db36d1fe3614c
-  json (2.9.1) sha256=d2bdef4644052fad91c1785d48263756fe32fcac08b96a20bb15840e96550d11
+  json (2.10.1) sha256=ddc88ad91a1baf3f0038c174f253af3b086d30dc74db17ca4259bbde982f94dc
   language_server-protocol (3.17.0.3) sha256=3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f
-  logger (1.6.5) sha256=c3cfe56d01656490ddd103d38b8993d73d86296adebc5f58cefc9ec03741e56b
+  logger (1.6.6) sha256=dd618d24e637715472732e7eed02e33cfbdf56deaad225edd0f1f89d38024017
   mini_portile2 (2.8.8) sha256=8e47136cdac04ce81750bb6c09733b37895bf06962554e4b4056d78168d70a75
   minitest (5.25.4) sha256=9cf2cae25ac4dfc90c988ebc3b917f53c054978b673273da1bd20bcb0778f947
   mustermann (3.0.3) sha256=d1f8e9ba2ddaed47150ddf81f6a7ea046826b64c672fbc92d83bce6b70657e88
@@ -185,7 +186,7 @@ CHECKSUMS
   parser (3.3.6.0) sha256=25d4e67cc4f0f7cab9a2ae1f38e2005b6904d2ea13c34734511d0faad038bc3b
   puma (6.6.0) sha256=f25c06873eb3d5de5f0a4ebc783acc81a4ccfe580c760cfe323497798018ad87
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.1.8) sha256=d3fbcbca43dc2b43c9c6d7dfbac01667ae58643c42cea10013d0da970218a1b1
+  rack (3.1.10) sha256=5e873127d04704c8121528b1ce04c551b5493a78291cace896b059a2a44bcb12
   rack-protection (4.1.1) sha256=51a254a5d574a7f0ca4f0672025ce2a5ef7c8c3bd09c431349d683e825d7d16a
   rack-session (2.1.0) sha256=437c3916535b58ef71c816ce4a2dee0a01c8a52ae6077dc2b6cd19085760a290
   rackup (2.2.1) sha256=f737191fd5c5b348b7f0a4412a3b86383f88c43e13b8217b63d4c8d90b9e798d
@@ -196,7 +197,7 @@ CHECKSUMS
   rspec-expectations (3.13.3) sha256=0e6b5af59b900147698ea0ff80456c4f2e69cac4394fbd392fbd1ca561f66c58
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
-  rubocop (1.71.1) sha256=d3dfd1e484a3a619dcf76c6a4fba694cd833921e4fd254d111845c26bcecfcfa
+  rubocop (1.71.2) sha256=9a7b7501aac661a338ed7ff2a5eba78e581759e1f0d3c82362b2ca217ed3f97f
   rubocop-ast (1.38.0) sha256=4fdf6792fe443a9a18acb12dbc8225d0d64cd1654e41fedb30e79c18edbb26ae
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and dependency upgrades in the `Gemfile`. The most important changes include adding permissions to the Docker publish workflow, updating action versions in the workflow, and upgrading several gems.

### GitHub Actions workflow updates:
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R13-R17): Added permissions for actions, contents, packages, and security-events to the build job.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L21-R48): Updated the versions of several actions used in the workflow to their latest versions. The actions updated include `find-latest-tag`, `setup-qemu-action`, `setup-buildx-action`, `login-action`, and `build-push-action`. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L21-R48) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L54-R59)

### Dependency upgrades:
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL4-R12): Upgraded the versions of `grape`, `json`, `logger`, `rack`, and `rubocop` gems to their latest releases.