### PR TITLE
updated ruby and gem versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Description: Dockerfile for qbop
-FROM ruby:3.4.4-slim
+FROM ruby:3.4.5-slim
 
 # set the version environment variable
 ARG VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'faraday', '~> 2.13', '>= 2.13.1'
+gem 'faraday', '~> 2.13', '>= 2.13.2'
 gem 'grape', '~> 2.4'
-gem 'json', '~> 2.12', '>= 2.12.2'
+gem 'json', '~> 2.13'
 gem 'logger', '~> 1.7'
 gem 'open3', '~> 0.2.1'
 gem 'puma', '~> 6.6'
@@ -10,8 +10,8 @@ gem 'rack', '~> 3.1', '>= 3.1.16'
 gem 'rack-session', '~> 2.1', '>= 2.1.1'
 gem 'rackup', '~> 2.2', '>= 2.2.1'
 gem 'rspec', '~> 3.13', '>= 3.13.1'
-gem 'rubocop', '~> 1.77', require: false
+gem 'rubocop', '~> 1.78', require: false
 gem 'sinatra', '~> 4.1', '>= 4.1.1'
-gem 'sqlite3', '~> 2.7'
+gem 'sqlite3', '~> 2.7', '>= 2.7.3'
 gem 'sucker_punch', '~> 3.2'
 gem 'uri', '~> 1.0', '>= 1.0.3'


### PR DESCRIPTION
This pull request includes updates to dependencies in the `Dockerfile` and `Gemfile` to address version upgrades for better compatibility and stability.

### Dependency Updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the Ruby base image from `ruby:3.4.4-slim` to `ruby:3.4.5-slim` to include the latest patches and improvements.

* `Gemfile`:
  - Upgraded `faraday` to `>= 2.13.2` for minor improvements and fixes.
  - Updated `json` to `~> 2.13` to align with the latest version.
  - Bumped `rubocop` to `~> 1.78` for updated linting rules and features.
  - Enhanced `sqlite3` dependency to `>= 2.7.3` for additional stability.