### PR TITLE
updated guibranco/github-file-reader-action-v2 to current version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - 
         name: Read file contents
-        uses: guibranco/github-file-reader-action-v2@140838a4964c6104b718a86a1faa57294a8524c0 # v2.2.822
+        uses: guibranco/github-file-reader-action-v2@a8cab27393bd80297285847628425a8be3e575d3 # v2.2.842
         id: file-contents
         with:
           path: "version.yml"


### PR DESCRIPTION
This pull request updates the version of an action used in the `.github/workflows/docker-publish.yml` workflow file. The update ensures the workflow uses the latest version of the `guibranco/github-file-reader-action-v2`.

* Workflow update:
  * [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L39-R39): Updated the `guibranco/github-file-reader-action-v2` action from version `v2.2.822` to `v2.2.842` for the "Read file contents" step.