### PR TITLE
Update default values for basic auth variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ There is also an unmaintained (by me) [community compose directory](https://gith
 | `QBIT_ADDR` | | The IP address of your qBittorrent app. Requires `http(s)://` and no trailing slash. |
 | `QBIT_USER` | | qBittorrent username |
 | `QBIT_PASS` | | qBittorrent password |
-| `BASIC_AUTH_ENABLED` | `false` | Enable basic auth. If `true`, subsequent `BASIC_AUTH` variables are required.
-| `BASIC_AUTH_USER` | | Set basic auth username
-| `BASIC_AUTH_PASS` | | Set basic auth password
+| `BASIC_AUTH_ENABLED` | `false` | Enable basic auth. If `true`, subsequent `BASIC_AUTH` variables are used. |
+| `BASIC_AUTH_USER` | `admin` | Set basic auth username |
+| `BASIC_AUTH_PASS` | `admin` | Set basic auth password |


### PR DESCRIPTION
Set default values for BASIC_AUTH_USER and BASIC_AUTH_PASS to 'admin' and clarified the description for BASIC_AUTH_ENABLED in the documentation.