### PR TITLE
Rename Docker GitHub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: qbop_ci
+name: Docker
 
 on:
   pull_request:


### PR DESCRIPTION
Renames the GitHub Actions workflow file from docker-publish.yml to docker.yml and updates the workflow display name from qbop_ci to Docker so the CI pipeline is labeled consistently.