### PR TITLE
Enable Rodauth browser auth; separate API auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ Pull requests are built without publishing an image. Main-branch builds identify
 | `QBIT_USER` | | qBittorrent username. Used when `QBIT_API_KEY` is not set. |
 | `QBIT_PASS` | | qBittorrent password. Used when `QBIT_API_KEY` is not set. |
 | `QBIT_SSL_VERIFY` | `false` | [`true`/`false`] Verify qBittorrent TLS certificates. Defaults to `false` for self-signed/private deployments. |
-| `BASIC_AUTH_ENABLED` | `false` | Enable basic auth. If `true`, subsequent `BASIC_AUTH` variables are used. |
-| `BASIC_AUTH_USER` | `admin` | Set basic auth username |
-| `BASIC_AUTH_PASS` | `admin` | Set basic auth password |
+| `WEB_AUTH_ENABLED` | `true` | Require browser authentication for the web UI. Disable only if the UI is protected by another trusted access layer. |
+| `BASIC_AUTH_ENABLED` | `false` | Enable HTTP Basic Auth for the API. If `true`, the subsequent `BASIC_AUTH` variables are used. |
+| `BASIC_AUTH_USER` | `admin` | Set the API Basic Auth username. |
+| `BASIC_AUTH_PASS` | `admin` | Set the API Basic Auth password. |
 
 ## Authentication development status
 
-qbop now includes a Rodauth foundation for the browser authentication planned for qbop 3.0. Rodauth is integrated as a small Roda middleware in front of the existing Sinatra web UI and Grape API, but Rodauth sessions do not protect either application yet. Existing HTTP Basic Authentication remains the active optional authentication mechanism and its environment variables are unchanged.
+Browser authentication is enabled by default. On the first browser visit, qbop prompts you to create the single administrator account at `/setup`. Successful setup signs you in automatically. Subsequent visits require the administrator email and password at `/login`, and the web UI provides a sign-out control.
 
-The authentication schema deliberately supports one administrator account. A database check plus a unique fixed account key enforce that invariant even if account-creation attempts race. Public account creation and first-run setup are not available; the Rodauth account-creation feature is enabled only for internal provisioning and tests.
+The authentication schema deliberately supports one administrator account. A database check plus a unique fixed account key enforce that invariant even if setup attempts race. After the account is created, `/setup` is unavailable. Set `WEB_AUTH_ENABLED=false` to disable browser authentication; this also makes `/setup` unavailable and does not change API authentication.
 
 Browser sessions use an encrypted `qbop.session` cookie with `HttpOnly` and `SameSite=Lax`. The persisted secret in `data/session_secret.txt` is generated automatically with restrictive permissions, so there is no new required configuration. Cookies are also marked `Secure` when Rack identifies the request as HTTPS, including through `X-Forwarded-Proto: https`; HTTPS reverse proxies must forward the original scheme.
 
-The first-run browser setup flow and revocable API keys will be implemented in later work. WebAuthn/passkeys remain a separate future enhancement.
+During qbop 3.0 development, the Grape API continues to use the existing optional HTTP Basic Auth controlled by `BASIC_AUTH_ENABLED`, `BASIC_AUTH_USER`, and `BASIC_AUTH_PASS`. Its behavior and default-disabled setting are unchanged. API authentication will move to revocable API keys before the final qbop 3.0 release; WebAuthn/passkeys remain a separate future enhancement.
 
 ## Usage
 ### Query Parameters

--- a/config.ru
+++ b/config.ru
@@ -23,7 +23,7 @@ Dir['./models/*.rb'].sort.each { |file| require_relative file }
 # seed tables if empty
 Service::Seed.new
 
-# build the web application; Basic Auth remains the active authentication layer
+# build the web application with Rodauth for the UI and optional Basic Auth for the API
 run Framework::Application.build
 
 # start the job(s)

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - LOG_LINES=
       - LOG_REVERSE=
       - LOG_TO_STDOUT=
+      - WEB_AUTH_ENABLED=true
       - BASIC_AUTH_ENABLED=
       - BASIC_AUTH_USER=
       - BASIC_AUTH_PASS=

--- a/framework/application.rb
+++ b/framework/application.rb
@@ -1,22 +1,36 @@
 module Framework
   # Builds qbop's Rack middleware stack around its Sinatra and Grape apps.
   class Application
-    def self.build(session_secret_path: 'data/session_secret.txt') # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    def self.build(session_secret_path: 'data/session_secret.txt')
       helpers = Service::Helpers.new
       session_secret = SessionSecret.load_or_create(session_secret_path)
+      web = web_app(session_secret)
+      api = api_app(helpers)
 
+      lambda do |env|
+        path = env.fetch('PATH_INFO', '')
+        app = path == '/api' || path.start_with?('/api/') ? api : web
+        app.call(env)
+      end
+    end
+
+    def self.web_app(session_secret)
       Rack::Builder.new do
-        if helpers.env_variables[:basic_auth_enabled] == 'true'
-          use Rack::Auth::Basic, 'Restricted Content' do |username, password|
-            username.eql?(helpers.env_variables[:basic_auth_user]) &&
-              password.eql?(helpers.env_variables[:basic_auth_pass])
-          end
-        end
-
         use SessionMiddleware, secret: session_secret
         use Authentication
-        run Rack::Cascade.new([Web, API])
+        run Web
       end.to_app
     end
+    private_class_method :web_app
+
+    def self.api_app(helpers)
+      return API unless helpers.env_variables[:basic_auth_enabled] == 'true'
+
+      Rack::Auth::Basic.new(API, 'Restricted Content') do |username, password|
+        username.eql?(helpers.env_variables[:basic_auth_user]) &&
+          password.eql?(helpers.env_variables[:basic_auth_pass])
+      end
+    end
+    private_class_method :api_app
   end
 end

--- a/framework/authentication.rb
+++ b/framework/authentication.rb
@@ -1,5 +1,5 @@
 module Framework
-  # Rodauth middleware for qbop's future browser authentication.
+  # Rodauth middleware for qbop's browser authentication.
   class Authentication < Roda
     plugin :middleware
 
@@ -7,17 +7,34 @@ module Framework
       db { DB }
       enable :login, :logout, :create_account, :internal_request
 
-      prefix '/auth'
-      create_account_route nil
+      prefix ''
+      create_account_route 'setup'
+      require_login_confirmation? false
+
+      login_label 'Email'
+      login_page_title 'Sign in to qbop'
+      login_button 'Sign in'
+      create_account_page_title 'Welcome to qbop'
+      create_account_button 'Create account'
+
+      before_login_route do
+        helpers = Service::Helpers.new
+        web_auth_enabled = helpers.true?(helpers.env_variables[:web_auth_enabled])
+        redirect '/setup' if web_auth_enabled && db[accounts_table].count.zero?
+      end
     end
     plugin :route_csrf, csrf_failure: :empty_403 # rubocop:disable Naming/VariableNumber
 
     route do |r|
       env['rodauth'] = rodauth
 
-      r.on 'auth' do
-        r.rodauth
+      if r.path == '/setup'
+        helpers = Service::Helpers.new
+        web_auth_enabled = helpers.true?(helpers.env_variables[:web_auth_enabled])
+        r.halt [404, {}, []] unless web_auth_enabled && DB[:accounts].count.zero?
       end
+
+      r.rodauth
     end
   end
 end

--- a/framework/session_middleware.rb
+++ b/framework/session_middleware.rb
@@ -12,8 +12,8 @@ module Framework
     }.freeze
 
     def initialize(app, secret:)
-      @http = Rack::Session::Cookie.new(app, **COOKIE_OPTIONS, secret: secret, secure: false)
-      @https = Rack::Session::Cookie.new(app, **COOKIE_OPTIONS, secret: secret, secure: true)
+      @http = Rack::Session::Cookie.new(app, **COOKIE_OPTIONS, secrets: [secret], secure: false)
+      @https = Rack::Session::Cookie.new(app, **COOKIE_OPTIONS, secrets: [secret], secure: true)
     end
 
     def call(env)

--- a/framework/web.rb
+++ b/framework/web.rb
@@ -1,7 +1,12 @@
 module Framework
   # The Web class is a Sinatra application that provides qbop's web UI routes.
-  class Web < Sinatra::Application
+  class Web < Sinatra::Application # rubocop:disable Metrics/ClassLength
     before do
+      unless public_asset_request? || !web_auth_enabled?
+        authentication = request.env.fetch('rodauth')
+        DB[:accounts].count.zero? ? redirect('/setup') : authentication.require_authentication
+      end
+
       update = Notification.select(:info, :active).where(name: 'update_available').first
       @recent_tag = update&.info
       @update_available = Service::Helpers.new.release_build? && (update&.active || false)
@@ -121,6 +126,7 @@ module Framework
       @qbit_user = ENV['QBIT_USER']
       @qbit_pass = '***'
       @qbit_ssl_verify = helpers.true?(ENV['QBIT_SSL_VERIFY'])
+      @web_auth_enabled = helpers.true?(helpers.env_variables[:web_auth_enabled])
       @basic_auth_enabled = helpers.true?(ENV['BASIC_AUTH_ENABLED'])
       @basic_auth_user = ENV['BASIC_AUTH_USER']
       @basic_auth_pass = '***'
@@ -128,6 +134,17 @@ module Framework
       @gemfile = helpers.gemfile_to_a
 
       erb :about
+    end
+
+    private
+
+    def public_asset_request?
+      request.path_info.start_with?('/css/', '/images/')
+    end
+
+    def web_auth_enabled?
+      helpers = Service::Helpers.new
+      helpers.true?(helpers.env_variables[:web_auth_enabled])
     end
   end
 end

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -52,6 +52,27 @@ color: var(--primary-color);
   gap: 0.5rem;
 }
 
+.auth-page {
+  margin: 4rem auto;
+  max-width: 32rem;
+}
+
+.auth-form {
+  border: 1px solid var(--font-color);
+  margin-top: 2rem;
+  padding: 1.5rem;
+}
+
+.auth-form .form-group {
+  margin-bottom: 1rem;
+}
+
+.logout-control {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
 .history-table-wrapper {
   overflow-x: auto;
 }

--- a/public/css/light.css
+++ b/public/css/light.css
@@ -52,6 +52,27 @@ color: var(--primary-color);
   gap: 0.5rem;
 }
 
+.auth-page {
+  margin: 4rem auto;
+  max-width: 32rem;
+}
+
+.auth-form {
+  border: 1px solid var(--font-color);
+  margin-top: 2rem;
+  padding: 1.5rem;
+}
+
+.auth-form .form-group {
+  margin-bottom: 1rem;
+}
+
+.logout-control {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
 .history-table-wrapper {
   overflow-x: auto;
 }

--- a/service/helpers.rb
+++ b/service/helpers.rb
@@ -29,6 +29,7 @@ module Service
         log_lines: ENV['LOG_LINES'] || 50,
         log_reverse: ENV['LOG_REVERSE'] || 'false',
         log_to_stdout: ENV['LOG_TO_STDOUT'] || 'false',
+        web_auth_enabled: ENV['WEB_AUTH_ENABLED'] || 'true',
         basic_auth_enabled: ENV['BASIC_AUTH_ENABLED'] || 'false',
         basic_auth_user: ENV['BASIC_AUTH_USER'] || 'admin',
         basic_auth_pass: ENV['BASIC_AUTH_PASS'] || 'admin'

--- a/spec/framework/application_spec.rb
+++ b/spec/framework/application_spec.rb
@@ -2,8 +2,10 @@ require 'bundler/setup'
 Bundler.require(:default)
 
 require 'base64'
+require 'cgi'
 require 'rack/mock'
 require 'tmpdir'
+require 'uri'
 require_relative '../support/database_helper'
 SpecDatabase.reset!
 
@@ -19,10 +21,71 @@ require_relative '../../framework/application'
 Framework::Web.set :environment, :test
 Framework::Web.set :run, false
 Framework::Web.set :views, File.expand_path('../../views', __dir__)
+Framework::Web.set :public_folder, File.expand_path('../../public', __dir__)
+Framework::Web.set :static, true
+
+# Maintains a Rack cookie jar while exercising the complete qbop application.
+class ApplicationSessionClient
+  def initialize(app)
+    @request = Rack::MockRequest.new(app)
+  end
+
+  def get(path, headers = {})
+    record_cookie(@request.get(path, request_headers.merge(headers)))
+  end
+
+  def post(path, params = {}, headers = {})
+    record_cookie(
+      @request.post(
+        path,
+        request_headers.merge(
+          headers,
+          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+          input: Rack::Utils.build_query(params)
+        )
+      )
+    )
+  end
+
+  private
+
+  def request_headers
+    @cookie ? { 'HTTP_COOKIE' => @cookie } : {}
+  end
+
+  def record_cookie(response)
+    if (set_cookie = response.get_header('set-cookie'))
+      @cookie = set_cookie.split(';', 2).first
+    end
+    response
+  end
+end
 
 RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
+  def csrf_token(response)
+    CGI.unescapeHTML(response.body.match(/name="_csrf" value="([^"]+)"/)[1])
+  end
+
+  def app
+    described_class.build(session_secret_path: File.join(Dir.mktmpdir, 'session_secret.txt'))
+  end
+
+  def basic_auth(username = 'existing-user', password = 'existing-password')
+    "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
+  end
+
+  def create_account
+    Framework::Authentication.rodauth.create_account(
+      login: 'admin@example.com', password: 'correct horse battery staple'
+    )
+  end
+
+  def redirect_path(response)
+    URI(response['location']).path
+  end
+
   around do |example|
-    keys = %w[BASIC_AUTH_ENABLED BASIC_AUTH_USER BASIC_AUTH_PASS]
+    keys = %w[WEB_AUTH_ENABLED BASIC_AUTH_ENABLED BASIC_AUTH_USER BASIC_AUTH_PASS]
     original_env = keys.to_h { |key| [key, ENV[key]] }
     keys.each { |key| ENV.delete(key) }
     example.run
@@ -38,38 +101,158 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  def app
-    described_class.build(session_secret_path: File.join(Dir.mktmpdir, 'session_secret.txt'))
+  it 'directs a fresh installation to setup' do
+    request = Rack::MockRequest.new(app)
+    response = request.get('/')
+
+    expect(response.status).to eq(302)
+    expect(redirect_path(response)).to eq('/setup')
+    expect(request.get('/setup').status).to eq(200)
   end
 
-  def basic_auth
-    "Basic #{Base64.strict_encode64('existing-user:existing-password')}"
+  it 'creates and authenticates the administrator through the real application stack' do
+    client = ApplicationSessionClient.new(app)
+    setup_page = client.get('/setup')
+    setup_response = client.post(
+      '/setup',
+      login: 'admin@example.com',
+      password: 'correct horse battery staple',
+      'password-confirm': 'correct horse battery staple',
+      _csrf: csrf_token(setup_page)
+    )
+    home = client.get('/')
+
+    expect(setup_response.status).to eq(302)
+    expect(redirect_path(setup_response)).to eq('/')
+    expect(home.status).to eq(200)
+    expect(home.body).to include('protonvpn', 'action="/logout"', 'sign out')
+    expect(DB[:accounts].count).to eq(1)
+    expect(client.get('/setup').status).to eq(404)
   end
 
-  it 'keeps web and API routes available without authentication when Basic Auth is disabled' do
+  it 'requires login after an account has been provisioned' do
+    create_account
+    request = Rack::MockRequest.new(app)
+    response = request.get('/history')
+
+    expect(response.status).to eq(302)
+    expect(redirect_path(response)).to eq('/login')
+  end
+
+  it 'allows login, logout, and then requires login again' do
+    create_account
+    client = ApplicationSessionClient.new(app)
+    login_page = client.get('/login')
+    invalid_login = client.post(
+      '/login',
+      login: 'admin@example.com', password: 'incorrect password', _csrf: csrf_token(login_page)
+    )
+    login_page = client.get('/login')
+    login_response = client.post(
+      '/login',
+      login: 'admin@example.com', password: 'correct horse battery staple', _csrf: csrf_token(login_page)
+    )
+    home = client.get('/')
+    logout_response = client.post('/logout', _csrf: csrf_token(home))
+    protected_response = client.get('/')
+
+    expect(invalid_login.status).to eq(401)
+    expect(login_response.status).to eq(302)
+    expect(redirect_path(login_response)).to eq('/')
+    expect(home.status).to eq(200)
+    expect(logout_response.status).to eq(302)
+    expect(redirect_path(logout_response)).to eq('/login')
+    expect(protected_response.status).to eq(302)
+    expect(redirect_path(protected_response)).to eq('/login')
+  end
+
+  it 'serves authentication page assets without a session' do
     request = Rack::MockRequest.new(app)
 
-    expect(request.get('/').status).to eq(200)
-    expect(request.get('/api/stats').status).to eq(200)
+    expect(request.get('/css/dark.css').status).to eq(200)
+    expect(request.get('/images/dark/favicon-dark.svg').status).to eq(200)
   end
 
-  it 'keeps Basic Auth authoritative for both web and API routes' do
+  it 'allows direct web access and makes setup unavailable when web authentication is disabled' do
+    ENV['WEB_AUTH_ENABLED'] = 'false'
+    request = Rack::MockRequest.new(app)
+    home = request.get('/')
+
+    expect(home.status).to eq(200)
+    expect(home.body).not_to include('action="/logout"', 'sign out')
+    expect(request.get('/history').status).to eq(200)
+    expect(request.get('/setup').status).to eq(404)
+    expect(request.post('/setup').status).to eq(404)
+    expect(DB[:accounts].count).to eq(0)
+  end
+
+  it 'hides the logout control when web authentication is disabled for an existing session' do
+    create_account
+    client = ApplicationSessionClient.new(app)
+    login_page = client.get('/login')
+    client.post(
+      '/login',
+      login: 'admin@example.com', password: 'correct horse battery staple', _csrf: csrf_token(login_page)
+    )
+
+    ENV['WEB_AUTH_ENABLED'] = 'false'
+    home = client.get('/')
+
+    expect(home.status).to eq(200)
+    expect(home.body).not_to include('action="/logout"', 'sign out')
+  end
+
+  it 'leaves the API public by default regardless of browser authentication' do
+    ENV['BASIC_AUTH_ENABLED'] = 'false'
+    request = Rack::MockRequest.new(app)
+    expected_response = Rack::MockRequest.new(Framework::API).get('/api/stats')
+    response = request.get('/api/stats')
+
+    expect(response.status).to eq(expected_response.status)
+    expect(response['content-type']).to eq(expected_response['content-type'])
+    expect(response.body).to eq(expected_response.body)
+    ENV['WEB_AUTH_ENABLED'] = 'false'
+    expect(Rack::MockRequest.new(app).get('/api/stats').body).to eq(expected_response.body)
+  end
+
+  it 'protects only the API when Basic Auth is enabled' do
     ENV['BASIC_AUTH_ENABLED'] = 'true'
     ENV['BASIC_AUTH_USER'] = 'existing-user'
     ENV['BASIC_AUTH_PASS'] = 'existing-password'
+    ENV['WEB_AUTH_ENABLED'] = 'false'
     request = Rack::MockRequest.new(app)
 
-    expect(request.get('/').status).to eq(401)
+    expect(request.get('/').status).to eq(200)
     expect(request.get('/api/stats').status).to eq(401)
-    expect(request.get('/', 'HTTP_AUTHORIZATION' => basic_auth).status).to eq(200)
+    expect(request.get('/api/stats', 'HTTP_AUTHORIZATION' => basic_auth('wrong', 'credentials')).status).to eq(401)
     expect(request.get('/api/stats', 'HTTP_AUTHORIZATION' => basic_auth).status).to eq(200)
+    expect(request.get('/api/health', 'HTTP_AUTHORIZATION' => basic_auth).status).to eq(200)
+    expect(request.get('/not-a-route').status).to eq(404)
   end
 
-  it 'does not expose a public account-creation endpoint' do
+  it 'routes API paths directly to Grape instead of the browser stack' do
+    expect(Framework::Web).not_to receive(:call)
+
+    response = Rack::MockRequest.new(app).get('/api/stats')
+
+    expect(response.status).to eq(200)
+    expect(response.headers).not_to include('set-cookie')
+  end
+
+  it 'preserves the existing exact Basic Auth enablement semantics' do
+    ENV['BASIC_AUTH_ENABLED'] = 'TRUE'
     request = Rack::MockRequest.new(app)
 
+    expect(request.get('/api/stats').status).to eq(200)
+  end
+
+  it 'does not expose the former authentication routes' do
+    ENV['WEB_AUTH_ENABLED'] = 'false'
+    request = Rack::MockRequest.new(app)
+
+    expect(request.get('/auth/login').status).to eq(404)
+    expect(request.get('/auth/logout').status).to eq(404)
     expect(request.get('/auth/create-account').status).to eq(404)
     expect(request.post('/auth/create-account').status).to eq(404)
-    expect(request.get('/auth/login').body).not_to include('/auth/create-account')
   end
 end

--- a/spec/framework/authentication_spec.rb
+++ b/spec/framework/authentication_spec.rb
@@ -20,7 +20,7 @@ class AuthenticationSessionClient
     record_cookie(@request.get(path, request_headers))
   end
 
-  def post(path, params)
+  def post(path, params = {})
     record_cookie(
       @request.post(
         path,
@@ -65,22 +65,90 @@ RSpec.describe Framework::Authentication do # rubocop:disable Metrics/BlockLengt
     end.to_app
   end
 
+  def create_account
+    described_class.rodauth.create_account(login: 'admin@example.com', password: 'correct horse battery staple')
+  end
+
+  around do |example|
+    web_auth_enabled = ENV['WEB_AUTH_ENABLED']
+    ENV.delete('WEB_AUTH_ENABLED')
+    example.run
+  ensure
+    web_auth_enabled.nil? ? ENV.delete('WEB_AUTH_ENABLED') : ENV['WEB_AUTH_ENABLED'] = web_auth_enabled
+  end
+
   before do
     SpecDatabase.reset!
-    described_class.rodauth.create_account(login: 'admin@example.com', password: 'correct horse battery staple')
     @client = AuthenticationSessionClient.new(build_app)
   end
 
-  it 'creates the single account internally with a bcrypt password hash' do
+  it 'renders a qbop-styled setup form with the intended fields' do
+    response = @client.get('/setup')
+
+    expect(response.status).to eq(200)
+    expect(response.body).to include('Welcome to qbop', 'Create the administrator account', 'Create account')
+    expect(response.body).to include('name="login"', 'name="password"', 'name="password-confirm"')
+    expect(response.body).not_to include('name="login-confirm"')
+  end
+
+  it 'creates the single account, hashes its password, and authenticates the session' do
+    setup_page = @client.get('/setup')
+    response = @client.post(
+      '/setup',
+      login: 'admin@example.com',
+      password: 'correct horse battery staple',
+      'password-confirm': 'correct horse battery staple',
+      _csrf: csrf_token(setup_page)
+    )
     account = DB[:accounts].first
     password_hash = DB[:account_password_hashes].where(id: account[:id]).get(:password_hash)
 
+    expect(response.status).to eq(302)
+    expect(response['location']).to end_with('/')
     expect(account[:email]).to eq('admin@example.com')
     expect(password_hash).to start_with('$2')
     expect(password_hash).not_to include('correct horse battery staple')
+    expect(@client.get('/auth-state').body).to match(/\Aauthenticated:\d+\z/)
   end
 
-  it 'rejects a second account through the internal Rodauth path' do
+  it 'rejects setup submissions without a route-specific CSRF token' do
+    response = @client.post(
+      '/setup',
+      login: 'admin@example.com',
+      password: 'correct horse battery staple',
+      'password-confirm': 'correct horse battery staple'
+    )
+
+    expect(response.status).to eq(403)
+    expect(DB[:accounts].count).to eq(0)
+  end
+
+  it 'returns 404 for setup GET and POST after provisioning' do
+    setup_page = @client.get('/setup')
+    setup_params = {
+      login: 'admin@example.com',
+      password: 'correct horse battery staple',
+      'password-confirm': 'correct horse battery staple',
+      _csrf: csrf_token(setup_page)
+    }
+    @client.post('/setup', setup_params)
+
+    expect(@client.get('/setup').status).to eq(404)
+    expect(@client.post('/setup', setup_params.merge(login: 'other@example.com')).status).to eq(404)
+    expect(DB[:accounts].count).to eq(1)
+  end
+
+  it 'returns 404 for setup GET and POST when web authentication is disabled' do
+    ENV['WEB_AUTH_ENABLED'] = 'false'
+
+    expect(@client.get('/setup').status).to eq(404)
+    expect(@client.post('/setup').status).to eq(404)
+    expect(DB[:accounts].count).to eq(0)
+  end
+
+  it 'keeps the database singleton protection effective for internal Rodauth requests' do
+    create_account
+
     expect do
       described_class.rodauth.create_account(login: 'other@example.com', password: 'another secure password')
     end.to raise_error(Rodauth::InternalRequestError)
@@ -89,31 +157,57 @@ RSpec.describe Framework::Authentication do # rubocop:disable Metrics/BlockLengt
     expect(DB[:account_password_hashes].count).to eq(1)
   end
 
-  it 'rejects an incorrect password without authenticating the session' do
-    login_page = @client.get('/auth/login')
-    response = @client.post(
-      '/auth/login',
-      login: 'admin@example.com', password: 'incorrect password', _csrf: csrf_token(login_page)
+  it 'redirects login to setup when no account exists' do
+    response = @client.get('/login')
+
+    expect(response.status).to eq(302)
+    expect(response['location']).to end_with('/setup')
+  end
+
+  it 'renders a qbop-styled login form after provisioning' do
+    create_account
+
+    response = @client.get('/login')
+
+    expect(response.status).to eq(200)
+    expect(response.body).to include('Sign in to qbop', 'name="login"', 'name="password"')
+    expect(response.body).not_to include('/setup')
+  end
+
+  it 'rejects an incorrect password and an unknown login' do
+    create_account
+    login_page = @client.get('/login')
+    invalid_password = @client.post(
+      '/login', login: 'admin@example.com', password: 'incorrect password', _csrf: csrf_token(login_page)
+    )
+    login_page = @client.get('/login')
+    unknown_login = @client.post(
+      '/login', login: 'unknown@example.com', password: 'incorrect password', _csrf: csrf_token(login_page)
     )
 
-    expect(response.status).to eq(401)
-    expect(response.body).to include('invalid password')
+    expect(invalid_password.status).to eq(401)
+    expect(invalid_password.body).to include('invalid password')
+    expect(unknown_login.status).to eq(401)
+    expect(unknown_login.body).to include('no matching login')
     expect(@client.get('/auth-state').body).to eq('anonymous')
   end
 
   it 'rejects login submissions without a route-specific CSRF token' do
+    create_account
+
     response = @client.post(
-      '/auth/login', login: 'admin@example.com', password: 'correct horse battery staple'
+      '/login', login: 'admin@example.com', password: 'correct horse battery staple'
     )
 
     expect(response.status).to eq(403)
     expect(@client.get('/auth-state').body).to eq('anonymous')
   end
 
-  it 'authenticates the password and recognizes the session on a later request' do
-    login_page = @client.get('/auth/login')
+  it 'authenticates valid credentials and recognizes the session later' do
+    create_account
+    login_page = @client.get('/login')
     response = @client.post(
-      '/auth/login',
+      '/login',
       login: 'admin@example.com', password: 'correct horse battery staple', _csrf: csrf_token(login_page)
     )
 
@@ -121,17 +215,22 @@ RSpec.describe Framework::Authentication do # rubocop:disable Metrics/BlockLengt
     expect(@client.get('/auth-state').body).to match(/\Aauthenticated:\d+\z/)
   end
 
-  it 'logs out the authenticated session' do
-    login_page = @client.get('/auth/login')
+  it 'rejects logout without CSRF and invalidates the session after a valid logout' do
+    create_account
+    login_page = @client.get('/login')
     @client.post(
-      '/auth/login',
+      '/login',
       login: 'admin@example.com', password: 'correct horse battery staple', _csrf: csrf_token(login_page)
     )
-    logout_page = @client.get('/auth/logout')
 
-    response = @client.post('/auth/logout', _csrf: csrf_token(logout_page))
+    expect(@client.post('/logout').status).to eq(403)
+    expect(@client.get('/auth-state').body).to match(/\Aauthenticated:\d+\z/)
+
+    logout_page = @client.get('/logout')
+    response = @client.post('/logout', _csrf: csrf_token(logout_page))
 
     expect(response.status).to eq(302)
+    expect(response['location']).to end_with('/login')
     expect(@client.get('/auth-state').body).to eq('anonymous')
   end
 end

--- a/spec/framework/session_middleware_spec.rb
+++ b/spec/framework/session_middleware_spec.rb
@@ -4,7 +4,7 @@ Bundler.require(:default)
 require 'rack/mock'
 require_relative '../../framework/session_middleware'
 
-RSpec.describe Framework::SessionMiddleware do
+RSpec.describe Framework::SessionMiddleware do # rubocop:disable Metrics/BlockLength
   let(:downstream_app) do
     lambda do |env|
       env.fetch('rack.session')['test'] = 'session-value'
@@ -13,6 +13,16 @@ RSpec.describe Framework::SessionMiddleware do
   end
 
   let(:app) { described_class.new(downstream_app, secret: 's' * 64) }
+
+  it 'configures encrypted sessions through the secrets option' do
+    http = app.instance_variable_get(:@http)
+    https = app.instance_variable_get(:@https)
+
+    expect(http.instance_variable_get(:@encryptors).length).to eq(1)
+    expect(https.instance_variable_get(:@encryptors).length).to eq(1)
+    expect(http.instance_variable_get(:@legacy_hmac_secret)).to be_nil
+    expect(https.instance_variable_get(:@legacy_hmac_secret)).to be_nil
+  end
 
   it 'uses HttpOnly SameSite=Lax cookies over HTTP' do
     cookie = Rack::MockRequest.new(app).get('/').get_header('set-cookie')

--- a/spec/framework/web_spec.rb
+++ b/spec/framework/web_spec.rb
@@ -17,14 +17,17 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
     version = ENV['VERSION']
     commit_sha = ENV['COMMIT_SHA']
     build_date = ENV['BUILD_DATE']
+    web_auth_enabled = ENV['WEB_AUTH_ENABLED']
     ENV.delete('VERSION')
     ENV.delete('COMMIT_SHA')
     ENV.delete('BUILD_DATE')
+    ENV['WEB_AUTH_ENABLED'] = 'false'
     example.run
   ensure
     version.nil? ? ENV.delete('VERSION') : ENV['VERSION'] = version
     commit_sha.nil? ? ENV.delete('COMMIT_SHA') : ENV['COMMIT_SHA'] = commit_sha
     build_date.nil? ? ENV.delete('BUILD_DATE') : ENV['BUILD_DATE'] = build_date
+    web_auth_enabled.nil? ? ENV.delete('WEB_AUTH_ENABLED') : ENV['WEB_AUTH_ENABLED'] = web_auth_enabled
   end
 
   before do

--- a/spec/service/helpers_spec.rb
+++ b/spec/service/helpers_spec.rb
@@ -26,6 +26,7 @@ HELPERS_SPEC_ENV_KEYS = %w[
   LOG_LINES
   LOG_REVERSE
   LOG_TO_STDOUT
+  WEB_AUTH_ENABLED
   BASIC_AUTH_ENABLED
   BASIC_AUTH_USER
   BASIC_AUTH_PASS
@@ -161,6 +162,11 @@ RSpec.describe Service::Helpers do # rubocop:disable Metrics/BlockLength
       end
       it 'does not return nil' do
         expect(Service::Helpers.new.env_variables[:log_to_stdout]).not_to eq(nil)
+      end
+    end
+    context 'when web_auth_enabled is not set' do
+      it 'returns web_auth_enabled as true' do
+        expect(Service::Helpers.new.env_variables[:web_auth_enabled]).to eq('true')
       end
     end
     context 'when basic_auth_enabled is not set' do

--- a/views/about.erb
+++ b/views/about.erb
@@ -88,6 +88,7 @@
   QBIT_USER: <%= @qbit_user %><br>
   QBIT_PASS: <%= @qbit_pass %><br>
   QBIT_SSL_VERIFY: <%= @qbit_ssl_verify %><br>
+  WEB_AUTH_ENABLED: <%= @web_auth_enabled %><br>
   BASIC_AUTH_ENABLED: <%= @basic_auth_enabled %><br>
   BASIC_AUTH_USER: <%= @basic_auth_user %><br>
   BASIC_AUTH_PASS: <%= @basic_auth_pass %>

--- a/views/create-account.erb
+++ b/views/create-account.erb
@@ -1,0 +1,14 @@
+<section class="auth-page">
+  <div class="logo terminal-prompt"><a href="/" class="no-style">qbop</a></div>
+  <h1>Welcome to qbop</h1>
+  <p>Create the administrator account for this qbop instance.</p>
+
+  <form method="post" class="auth-form" role="form" id="create-account-form">
+    <%= rodauth.create_account_additional_form_tags %>
+    <%= rodauth.csrf_tag %>
+    <%= rodauth.render('login-field') %>
+    <%= rodauth.render('password-field') %>
+    <%= rodauth.render('password-confirm-field') %>
+    <%= rodauth.button(rodauth.create_account_button, class: 'btn btn-default') %>
+  </form>
+</section>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,6 +41,14 @@
   </head>
   <body class="terminal">
     <div class="container">
+      <% authentication = request.env['rodauth'] %>
+      <% helpers = Service::Helpers.new %>
+      <% if authentication&.logged_in? && helpers.true?(helpers.env_variables[:web_auth_enabled]) %>
+      <form action="/logout" method="post" class="logout-control">
+        <%= authentication.csrf_tag('/logout') %>
+        <button class="btn btn-default btn-ghost" type="submit">sign out</button>
+      </form>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,0 +1,12 @@
+<section class="auth-page">
+  <div class="logo terminal-prompt"><a href="/" class="no-style">qbop</a></div>
+  <h1>Sign in to qbop</h1>
+
+  <form method="post" class="auth-form" role="form" id="login-form">
+    <%= rodauth.login_additional_form_tags %>
+    <%= rodauth.csrf_tag %>
+    <%= rodauth.render('login-field') %>
+    <%= rodauth.render('password-field') %>
+    <%= rodauth.button(rodauth.login_button, class: 'btn btn-default') %>
+  </form>
+</section>


### PR DESCRIPTION
Enable browser authentication (Rodauth) by default and add WEB_AUTH_ENABLED env var. Introduce setup/login views and styles, require a single admin account for the web UI, and show/hide logout controls. Route /api paths directly to the Grape API and make Basic Auth apply only to the API when BASIC_AUTH_ENABLED is set. Change session cookie setup to use Rack secrets, add helpers for WEB_AUTH_ENABLED, update docker-compose and README, and expand specs to cover the new auth and routing behavior.