### PR TITLE
Extract logout into nav partial and update styles

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -67,10 +67,20 @@ color: var(--primary-color);
   margin-bottom: 1rem;
 }
 
-.logout-control {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1rem;
+.nav-logout-form {
+  display: inline;
+  margin: 0;
+}
+
+.nav-logout-button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--primary-color);
+  cursor: pointer;
+  font: inherit;
+  margin: 0;
+  padding: 5px;
 }
 
 .history-table-wrapper {

--- a/public/css/light.css
+++ b/public/css/light.css
@@ -67,10 +67,20 @@ color: var(--primary-color);
   margin-bottom: 1rem;
 }
 
-.logout-control {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1rem;
+.nav-logout-form {
+  display: inline;
+  margin: 0;
+}
+
+.nav-logout-button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--primary-color);
+  cursor: pointer;
+  font: inherit;
+  margin: 0;
+  padding: 5px;
 }
 
 .history-table-wrapper {

--- a/spec/framework/application_spec.rb
+++ b/spec/framework/application_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     expect(redirect_path(setup_response)).to eq('/')
     expect(home.status).to eq(200)
     expect(home.body).to include('protonvpn', 'action="/logout"', 'sign out')
+    expect(home.body).to match(%r{href="/about">about</a></li>\s*<li class="nav-logout-item">})
     expect(DB[:accounts].count).to eq(1)
     expect(client.get('/setup').status).to eq(404)
   end

--- a/views/_logout.erb
+++ b/views/_logout.erb
@@ -1,0 +1,10 @@
+<% authentication = request.env['rodauth'] %>
+<% helpers = Service::Helpers.new %>
+<% if authentication&.logged_in? && helpers.true?(helpers.env_variables[:web_auth_enabled]) %>
+<li class="nav-logout-item">
+  <form action="/logout" method="post" class="nav-logout-form">
+    <%= authentication.csrf_tag('/logout') %>
+    <button class="menu-item nav-logout-button" type="submit">sign out</button>
+  </form>
+</li>
+<% end %>

--- a/views/about.erb
+++ b/views/about.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item" href="/tools">tools</a></li>
       <li><a class="menu-item" href="/logs">logs</a></li>
       <li><a class="menu-item active" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>

--- a/views/api_docs.erb
+++ b/views/api_docs.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item" href="/tools">tools</a></li>
       <li><a class="menu-item" href="/logs">logs</a></li>
       <li><a class="menu-item" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>

--- a/views/history.erb
+++ b/views/history.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item" href="/tools">tools</a></li>
       <li><a class="menu-item" href="/logs">logs</a></li>
       <li><a class="menu-item" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item" href="/tools">tools</a></li>
       <li><a class="menu-item" href="/logs">logs</a></li>
       <li><a class="menu-item" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,14 +41,6 @@
   </head>
   <body class="terminal">
     <div class="container">
-      <% authentication = request.env['rodauth'] %>
-      <% helpers = Service::Helpers.new %>
-      <% if authentication&.logged_in? && helpers.true?(helpers.env_variables[:web_auth_enabled]) %>
-      <form action="/logout" method="post" class="logout-control">
-        <%= authentication.csrf_tag('/logout') %>
-        <button class="btn btn-default btn-ghost" type="submit">sign out</button>
-      </form>
-      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/views/logs.erb
+++ b/views/logs.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item" href="/tools">tools</a></li>
       <li><a class="menu-item active" href="/logs">logs</a></li>
       <li><a class="menu-item" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>

--- a/views/tools.erb
+++ b/views/tools.erb
@@ -10,6 +10,7 @@
       <li><a class="menu-item active" href="/tools">tools</a></li>
       <li><a class="menu-item" href="/logs">logs</a></li>
       <li><a class="menu-item" href="/about">about</a></li>
+      <%= erb :_logout, layout: false %>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
Add views/_logout.erb to render the logout form inside the navigation when web auth is enabled; remove the inline logout form from layout. Update views (index, about, api_docs, history, logs, tools) to render the partial. Rename and style classes in public/css/{dark,light}.css (.nav-logout-form, .nav-logout-button) and update spec to match the new nav markup.