### PR TITLE
Publish Docker images for all branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - "**"
     tags:
       - "v*"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The container image is available [here](https://github.com/clajiness/qbop/pkgs/c
 Image tags are published as follows:
 - `latest` → most recent release
 - `main` → most recent build from the main branch
+- `<branch>` → most recent build from any pushed branch; invalid Docker tag characters such as `/` are replaced with `-`
 - `sha-<12-character commit SHA>` → exact commit used for any published image build
 - `v2` → latest `v2.x.x` release
 - `v2.minor` → latest patch release for that minor version, e.g. `v2.7`


### PR DESCRIPTION
This commit updates the Docker workflow to publish images for any pushed branch, not just `main`.

It also documents the new branch tag behavior in the README: branch names are used as Docker tags, with invalid characters replaced by `-`, alongside the existing release and SHA-based tags.