### PR TITLE
Move API key management to /api-keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Recommended upgrade sequence:
 3. Remove obsolete `BASIC_AUTH_*` environment variables.
 4. Start the 3.0 image normally. qbop runs its database migrations automatically during startup; no manual database editing is required.
 5. Create the administrator at `/setup`, unless browser authentication is disabled.
-6. Open `/api-docs` and create an API key.
+6. Open `/api-keys` and create an API key.
 7. Update every API client and monitoring check to send `Authorization: Bearer qbop_...`, including checks of `/api/health`.
 8. Restart qbop and verify the web UI, history, integrations, and authenticated API requests.
 
@@ -184,9 +184,9 @@ Every API endpoint requires a valid qbop API key, including `/api/health`. Inbou
 
 To configure an API client:
 
-1. Sign in to qbop and open `/api-docs` through **api** in the navigation.
-2. Review the endpoint documentation and scroll to **api keys**.
-3. Create a named API key.
+1. Sign in to qbop and open `/api-docs` through **api docs** in the navigation.
+2. Follow the **API Keys** link to `/api-keys`.
+3. Create a named API key there.
 4. Copy the complete `qbop_...` value immediately.
 5. Send it in the `Authorization` header:
 
@@ -194,9 +194,9 @@ To configure an API client:
    Authorization: Bearer qbop_xxxxxxxxx
    ```
 
-6. Revoke the old key from the same page when it is no longer needed.
+6. Revoke the old key from `/api-keys` when it is no longer needed.
 
-`/api-docs` combines the current endpoint documentation with API-key creation and revocation. API-key secrets are shown only once and cannot be recovered later. Create a replacement before revoking a key when rotating credentials. When browser authentication is disabled, `/api-docs` and its key-management section are accessible with the rest of the web UI, so protect that UI with a trusted external access layer.
+`/api-docs` is the API reference, and `/api-keys` provides API-key creation and revocation. API-key secrets are shown only once and cannot be recovered later. Create a replacement before revoking a key when rotating credentials. When browser authentication is disabled, `/api-keys` is accessible with the rest of the web UI, so protect that UI with a trusted external access layer.
 
 ## Usage
 

--- a/framework/api.rb
+++ b/framework/api.rb
@@ -9,7 +9,7 @@ module Framework
   # It sets the response format to JSON and prefixes all routes with '/api'.
   class API < Grape::API # rubocop:disable Metrics/ClassLength
     WIREGUARD_IMPORT_UNAVAILABLE =
-      'Proton WireGuard import is unavailable because OPNsense integration is disabled.'.freeze
+      'proton wireguard import is unavailable because opnsense integration is disabled.'.freeze
 
     format :json
     prefix :api
@@ -37,12 +37,12 @@ module Framework
 
         private_key = params['private_key'].to_s.strip
         error!({ 'error' => 'private_key is required' }, 422) if private_key.empty?
-        error!({ 'error' => 'private_key is not a valid WireGuard key' }, 422) unless valid_wireguard_key?(private_key)
+        error!({ 'error' => 'private_key is not a valid wireguard key' }, 422) unless valid_wireguard_key?(private_key)
 
         public_key = Service::Helpers.new.generate_wg_public_key(private_key)
         return public_key if valid_wireguard_key?(public_key)
 
-        error!({ 'error' => 'could not derive WireGuard public key' }, 422)
+        error!({ 'error' => 'could not derive wireguard public key' }, 422)
       end
 
       def valid_wireguard_key?(value)

--- a/framework/web.rb
+++ b/framework/web.rb
@@ -6,7 +6,7 @@ require_relative '../service/proton_wireguard_rotation'
 module Framework
   # The Web class is a Sinatra application that provides qbop's web UI routes.
   class Web < Sinatra::Application # rubocop:disable Metrics/ClassLength
-    WIREGUARD_IMPORT_UNAVAILABLE = 'Proton WireGuard import requires OPNsense integration.'.freeze
+    WIREGUARD_IMPORT_UNAVAILABLE = 'proton wireguard import requires opnsense integration.'.freeze
 
     before do
       unless public_asset_request? || public_authentication_request? || !web_auth_enabled?
@@ -19,7 +19,7 @@ module Framework
         halt 403 unless authentication.scope.valid_csrf?
       end
 
-      headers 'Cache-Control' => 'no-store' if api_docs_request? || tools_request?
+      headers 'Cache-Control' => 'no-store' if api_keys_request? || tools_request?
 
       update = Notification.select(:info, :active).where(name: 'update_available').first
       @recent_tag = update&.info
@@ -55,11 +55,15 @@ module Framework
     end
 
     get '/api-docs' do
+      erb :api_docs
+    end
+
+    get '/api-keys' do
       @new_api_key = request.session.delete(:new_api_key)
       @api_key_error = request.session.delete(:api_key_error)
       @api_keys = ApiKey.reverse_order(:created_at, :id).all
 
-      erb :api_docs
+      erb :api_keys
     end
 
     get '/account' do
@@ -92,23 +96,23 @@ module Framework
       erb :logged_out
     end
 
-    post '/api-docs/keys' do
+    post '/api-keys' do
       issued_key = ApiKey.issue(params['name'])
       request.session[:new_api_key] = issued_key.token
-      redirect '/api-docs', 303
+      redirect '/api-keys', 303
     rescue ApiKey::InvalidName => e
       request.session[:api_key_error] = e.message
-      redirect '/api-docs', 303
+      redirect '/api-keys', 303
     end
 
-    post '/api-docs/keys/:id/delete' do
+    post '/api-keys/:id/delete' do
       halt 404 unless params['id'].match?(/\A[1-9][0-9]*\z/)
 
       api_key = ApiKey[params['id'].to_i]
       halt 404 unless api_key
 
       api_key.delete
-      redirect '/api-docs', 303
+      redirect '/api-keys', 303
     end
 
     get '/tools' do
@@ -252,8 +256,8 @@ module Framework
       [AuthenticationConfig::OIDC_FAILURE_PATH, AuthenticationConfig::LOGGED_OUT_PATH].include?(request.path_info)
     end
 
-    def api_docs_request?
-      request.path_info == '/api-docs' || request.path_info.start_with?('/api-docs/')
+    def api_keys_request?
+      request.path_info == '/api-keys' || request.path_info.start_with?('/api-keys/')
     end
 
     def tools_request?
@@ -303,7 +307,7 @@ module Framework
     end
 
     def api_key_mutation_request?
-      request.path_info == '/api-docs/keys' || request.path_info.start_with?('/api-docs/keys/')
+      request.path_info == '/api-keys' || request.path_info.start_with?('/api-keys/')
     end
 
     def web_auth_enabled?

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -52,6 +52,18 @@
   overflow-x: auto;
 }
 
+.api-key-table-wrapper {
+  overflow-x: auto;
+}
+
+.api-key-table {
+  min-width: 48rem;
+}
+
+.api-endpoint pre {
+  overflow-x: auto;
+}
+
 .history-table {
   min-width: 50rem;
 }

--- a/public/css/light.css
+++ b/public/css/light.css
@@ -52,6 +52,18 @@
   overflow-x: auto;
 }
 
+.api-key-table-wrapper {
+  overflow-x: auto;
+}
+
+.api-key-table {
+  min-width: 48rem;
+}
+
+.api-endpoint pre {
+  overflow-x: auto;
+}
+
 .history-table {
   min-width: 50rem;
 }

--- a/service/opnsense.rb
+++ b/service/opnsense.rb
@@ -54,7 +54,7 @@ module Service
     rescue WireguardImportError
       raise
     rescue StandardError => e
-      raise WireguardImportError, "could not load OPNsense WireGuard targets: #{e.message}"
+      raise WireguardImportError, "could not load opnsense wireguard targets: #{e.message}"
     end
 
     def validate_wireguard_config
@@ -66,7 +66,7 @@ module Service
       missing = settings.filter_map { |name, value| name if value.to_s.strip.empty? }
       return if missing.empty?
 
-      raise WireguardImportError, "missing OPNsense configuration: #{missing.join(', ')}"
+      raise WireguardImportError, "missing opnsense configuration: #{missing.join(', ')}"
     end
 
     def wireguard_instance(uuid)
@@ -81,14 +81,14 @@ module Service
       response = request_json(
         :post, "/api/wireguard/server/set_server/#{uuid}", payload: { 'server' => payload }
       )
-      expect_result(response, 'saved', 'update the WireGuard instance')
+      expect_result(response, 'saved', 'update the wireguard instance')
     end
 
     def save_wireguard_peer(uuid, payload)
       response = request_json(
         :post, "/api/wireguard/client/set_client/#{uuid}", payload: { 'client' => payload }
       )
-      expect_result(response, 'saved', 'update the WireGuard peer')
+      expect_result(response, 'saved', 'update the wireguard peer')
     end
 
     def reconfigure_wireguard
@@ -97,7 +97,7 @@ module Service
         '/api/wireguard/service/reconfigure',
         timeout: WIREGUARD_RECONFIGURE_TIMEOUT
       )
-      expect_result(response, 'ok', 'apply the WireGuard configuration')
+      expect_result(response, 'ok', 'apply the wireguard configuration')
     end
 
     def wireguard_runtime
@@ -107,7 +107,7 @@ module Service
       records = response['rows']
       return records if records.is_a?(Array)
 
-      raise WireguardImportError, 'OPNsense did not return WireGuard runtime records'
+      raise WireguardImportError, 'opnsense did not return wireguard runtime records'
     end
 
     private
@@ -134,7 +134,7 @@ module Service
       response = request_json(:get, "/api/wireguard/#{type}/#{endpoint}/#{uuid}")
       response.fetch(type) do
         subject = type == 'server' ? 'instance' : 'peer'
-        raise WireguardImportError, "OPNsense did not return the existing #{subject}"
+        raise WireguardImportError, "opnsense did not return the existing #{subject}"
       end
     end
 
@@ -149,12 +149,12 @@ module Service
         end
       end
       unless response.status.to_i.between?(200, 299)
-        raise WireguardImportError, "OPNsense returned HTTP #{response.status} for #{path}"
+        raise WireguardImportError, "opnsense returned HTTP #{response.status} for #{path}"
       end
 
       JSON.parse(response.body)
     rescue JSON::ParserError
-      raise WireguardImportError, "OPNsense returned an invalid response for #{path}"
+      raise WireguardImportError, "opnsense returned an invalid response for #{path}"
     end
 
     def expect_result(response, expected, action)
@@ -162,7 +162,7 @@ module Service
 
       validations = response.fetch('validations', {}).map { |field, message| "#{field}: #{Array(message).join(', ')}" }
       detail = validations.empty? ? response['result'].to_s : validations.join('; ')
-      raise WireguardImportError, "OPNsense could not #{action}#{detail.empty? ? '' : ": #{detail}"}"
+      raise WireguardImportError, "opnsense could not #{action}#{detail.empty? ? '' : ": #{detail}"}"
     end
 
     def faraday_conn(config)

--- a/service/proton_wireguard.rb
+++ b/service/proton_wireguard.rb
@@ -22,12 +22,12 @@ module Service
 
     def self.peer_name_for(server_identifier)
       identifier = server_identifier.to_s
-      error = 'Unable to rename peer because a Proton server identifier was not found in the configuration.'
+      error = 'unable to rename peer because a proton server identifier was not found in the configuration.'
       raise ImportError, error unless identifier.match?(PROTON_SERVER_IDENTIFIER)
 
       prefix, _separator, number = identifier.rpartition('#')
       peer_name = "Proton_#{prefix}#{number}"
-      error = 'Unable to rename peer because the generated name is not valid for OPNsense.'
+      error = 'unable to rename peer because the generated name is not valid for opnsense.'
       raise ImportError, error unless peer_name.match?(OPNSENSE_PEER_NAME)
 
       peer_name
@@ -51,7 +51,7 @@ module Service
     def validate_config_text(config_text)
       config = config_text.to_s.dup.force_encoding(Encoding::UTF_8)
       raise ImportError, 'configuration must be valid UTF-8 text' unless config.valid_encoding?
-      raise ImportError, 'paste or upload a ProtonVPN WireGuard configuration' if config.strip.empty?
+      raise ImportError, 'paste or upload a protonvpn wireguard configuration' if config.strip.empty?
       raise ImportError, "configuration exceeds #{MAX_CONFIG_BYTES} bytes" if config.bytesize > MAX_CONFIG_BYTES
 
       config
@@ -97,7 +97,7 @@ module Service
     end
 
     def select_section(section, seen_sections)
-      raise ImportError, "unsupported WireGuard section [#{section}]" unless SUPPORTED_SETTINGS.key?(section)
+      raise ImportError, "unsupported wireguard section [#{section}]" unless SUPPORTED_SETTINGS.key?(section)
 
       seen_sections[section] += 1
       raise ImportError, "configuration must contain exactly one [#{section}] section" if seen_sections[section] > 1
@@ -110,7 +110,7 @@ module Service
 
       key, value = content.split('=', 2)&.map(&:strip)
       unless key && value && !key.empty? && !value.empty?
-        raise ImportError, "invalid WireGuard setting on line #{line_number}"
+        raise ImportError, "invalid wireguard setting on line #{line_number}"
       end
       unless SUPPORTED_SETTINGS.fetch(current_section).include?(key)
         raise ImportError, "unsupported #{current_section} setting #{key}"
@@ -132,11 +132,11 @@ module Service
 
     def validate_port_forwarding(metadata)
       if metadata[:moderate_nat] && metadata[:moderate_nat] != 'off'
-        raise ImportError, 'Moderate NAT is incompatible with ProtonVPN port forwarding'
+        raise ImportError, 'Moderate NAT is incompatible with protonvpn port forwarding'
       end
       return if metadata[:nat_pmp] == 'on'
 
-      raise ImportError, 'NAT-PMP (Port Forwarding) must be enabled in the ProtonVPN configuration'
+      raise ImportError, 'NAT-PMP (Port Forwarding) must be enabled in the protonvpn configuration'
     end
 
     def build_import(sections, metadata) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -169,11 +169,11 @@ module Service
     def validate_key(value, label)
       decoded = Base64.strict_decode64(value)
       valid = decoded.bytesize == 32 && Base64.strict_encode64(decoded) == value
-      raise ImportError, "#{label} is not a valid WireGuard key" unless valid
+      raise ImportError, "#{label} is not a valid wireguard key" unless valid
 
       value
     rescue ArgumentError, TypeError
-      raise ImportError, "#{label} is not a valid WireGuard key"
+      raise ImportError, "#{label} is not a valid wireguard key"
     end
 
     def derive_public_key(private_key)

--- a/service/proton_wireguard_rotation.rb
+++ b/service/proton_wireguard_rotation.rb
@@ -20,8 +20,8 @@ module Service
     def validate_request(instance_uuid:, peer_uuid:)
       @opnsense.validate_wireguard_config
       {
-        instance_uuid: validate_uuid(instance_uuid, 'Instance'),
-        peer_uuid: validate_uuid(peer_uuid, 'Peer')
+        instance_uuid: validate_uuid(instance_uuid, 'instance'),
+        peer_uuid: validate_uuid(peer_uuid, 'peer')
       }
     rescue Service::Opnsense::WireguardImportError => e
       raise Error, e.message
@@ -77,18 +77,18 @@ module Service
       state[:peer_name] = peer['name'].to_s
       state[:interface] = instance['interface'].to_s
       if state[:interface].empty?
-        raise Error, "OPNsense did not return the interface for instance #{state[:instance_name]}"
+        raise Error, "opnsense did not return the interface for instance #{state[:instance_name]}"
       end
 
       state[:original_enabled] = enabled?(instance['enabled'])
-      raise Error, "Instance #{state[:instance_name]} must be enabled before import" unless state[:original_enabled]
-      raise Error, "Peer #{state[:peer_name]} must be enabled before import" unless enabled?(peer['enabled'])
+      raise Error, "instance #{state[:instance_name]} must be enabled before import" unless state[:original_enabled]
+      raise Error, "peer #{state[:peer_name]} must be enabled before import" unless enabled?(peer['enabled'])
 
       instance_peers = selected_values(instance['peers'])
       state[:current_enabled] = state[:original_enabled]
       peer_instances = selected_values(peer['servers'])
       unless instance_peers == [state[:peer_uuid]] && peer_instances == [state[:instance_uuid]]
-        raise Error, 'The selected WireGuard instance and peer must be dedicated to each other.'
+        raise Error, 'the selected wireguard instance and peer must be dedicated to each other.'
       end
 
       state[:original_instance] = normalized_fields(instance, INSTANCE_FIELDS)
@@ -142,9 +142,9 @@ module Service
     end
 
     def addresses_for_existing_families(imported_value, existing_value, subject)
-      imported = addresses_with_families(imported_value, "Proton #{subject}")
+      imported = addresses_with_families(imported_value, "proton #{subject}")
       required_families = addresses_with_families(
-        existing_value, "adopted OPNsense #{subject}"
+        existing_value, "adopted opnsense #{subject}"
       ).map(&:last).uniq
       validate_required_families(imported, required_families, subject)
 
@@ -156,7 +156,7 @@ module Service
       return if missing_families.empty?
 
       missing = missing_families.map { |family| ADDRESS_FAMILY_NAMES.fetch(family) }.join(' and ')
-      raise Error, "Proton configuration is missing #{missing} required by the adopted OPNsense #{subject}"
+      raise Error, "proton configuration is missing #{missing} required by the adopted opnsense #{subject}"
     end
 
     def addresses_with_families(value, subject)
@@ -245,7 +245,7 @@ module Service
       active = @opnsense.wireguard_runtime.any? { |record| record['if'].to_s == state[:interface] }
       return unless active
 
-      raise Error, "OPNsense WireGuard instance #{state[:instance_name]} is still active after disable/apply"
+      raise Error, "opnsense wireguard instance #{state[:instance_name]} is still active after disable/apply"
     end
 
     def verify_instance_active(state, instance_public_key:, peer_public_key:, state_label:)
@@ -254,7 +254,7 @@ module Service
       peer_active = runtime_key_present?(records, 'peer', peer_public_key)
       return if instance_active && peer_active
 
-      raise Error, "OPNsense WireGuard instance #{state[:instance_name]} is not active with the #{state_label} keys"
+      raise Error, "opnsense wireguard instance #{state[:instance_name]} is not active with the #{state_label} keys"
     end
 
     def runtime_key_present?(records, type, public_key)
@@ -276,7 +276,7 @@ module Service
       message = if error.is_a?(Error) || error.is_a?(Service::Opnsense::WireguardImportError)
                   error.message
                 else
-                  "OPNsense WireGuard rotation failed: #{error.message}"
+                  "opnsense wireguard rotation failed: #{error.message}"
                 end
       Error.new("#{message}#{rollback_status(rollback_required, rollback_errors)}")
     end
@@ -291,12 +291,12 @@ module Service
     def with_lock
       File.open(@lock_path, File::RDWR | File::CREAT, 0o600) do |lock|
         acquired = lock.flock(File::LOCK_EX | File::LOCK_NB)
-        raise Busy, 'another OPNsense WireGuard rotation is already in progress' unless acquired
+        raise Busy, 'another opnsense wireguard rotation is already in progress' unless acquired
 
         yield
       end
     rescue SystemCallError => e
-      raise Error, "could not secure the OPNsense WireGuard rotation lock: #{e.message}"
+      raise Error, "could not secure the opnsense wireguard rotation lock: #{e.message}"
     end
 
     def validate_uuid(uuid, label)

--- a/spec/framework/api_spec.rb
+++ b/spec/framework/api_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Framework::API do # rubocop:disable Metrics/BlockLength
     response = api_post('/api/tools/pubkey', { private_key: private_key })
 
     expect(response.status).to eq(422)
-    expect(response_json(response)).to eq('error' => 'private_key is not a valid WireGuard key')
+    expect(response_json(response)).to eq('error' => 'private_key is not a valid wireguard key')
     expect(response.body).not_to include(private_key)
   end
 
@@ -198,7 +198,7 @@ RSpec.describe Framework::API do # rubocop:disable Metrics/BlockLength
     response = api_post('/api/tools/pubkey', { private_key: private_key })
 
     expect(response.status).to eq(422)
-    expect(response_json(response)).to eq('error' => 'could not derive WireGuard public key')
+    expect(response_json(response)).to eq('error' => 'could not derive wireguard public key')
     expect(response.body).not_to include(private_key, 'wg derivation failed')
   end
 
@@ -237,7 +237,7 @@ RSpec.describe Framework::API do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(503)
     expect(response_json(response)['error']).to eq(
-      'Proton WireGuard import is unavailable because OPNsense integration is disabled.'
+      'proton wireguard import is unavailable because opnsense integration is disabled.'
     )
   end
 
@@ -255,7 +255,7 @@ RSpec.describe Framework::API do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(503)
     expect(response_json(response)['error']).to eq(
-      'Proton WireGuard import is unavailable because OPNsense integration is disabled.'
+      'proton wireguard import is unavailable because opnsense integration is disabled.'
     )
     expect(response.body).not_to include('distinctive-skipped-api-private-config-value', 'PrivateKey')
   end
@@ -318,7 +318,7 @@ RSpec.describe Framework::API do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(422)
     expect(response_json(response)['error']).to include(
-      'Unable to rename peer because a Proton server identifier was not found'
+      'unable to rename peer because a proton server identifier was not found'
     )
   end
 

--- a/spec/framework/application_spec.rb
+++ b/spec/framework/application_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     expect(account_page.body).not_to include('style=')
 
     about_page = client.get('/about')
-    expect(about_page.body).to include('<h4><em>account</em></h4>', 'href="/account"')
+    expect(about_page.body).to include('<h4><em>account</em></h4>', 'href="/account"', 'href="/api-keys"')
     account_position = about_page.body.index('<h4><em>account</em></h4>')
     environment_position = about_page.body.index('<h4><em>env variables</em></h4>')
     expect(account_position).to be < environment_position
@@ -219,7 +219,8 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     {
       '/' => ['stats', '/'],
       '/history' => ['history', '/history'],
-      '/api-docs' => ['api', '/api-docs'],
+      '/api-docs' => ['api docs', '/api-docs'],
+      '/api-keys' => ['api docs', '/api-docs'],
       '/tools' => ['tools', '/tools'],
       '/logs' => ['logs', '/logs'],
       '/about' => ['about', '/about']
@@ -441,7 +442,8 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
 
     expect(home.status).to eq(200)
     expect(home.body).not_to include('action="/logout"', 'sign out')
-    expect(about.body).not_to include('href="/account"', '<h4><em>account</em></h4>')
+    expect(about.body).not_to include('href="/account"')
+    expect(about.body).to include('<h4><em>account</em></h4>', 'href="/api-keys"')
     expect(request.get('/history').status).to eq(200)
     expect(request.get('/setup').status).to eq(404)
     expect(request.post('/setup').status).to eq(404)
@@ -473,7 +475,8 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
 
     expect(home.status).to eq(200)
     expect(home.body).not_to include('action="/logout"', 'sign out')
-    expect(about.body).not_to include('href="/account"', '<h4><em>account</em></h4>')
+    expect(about.body).not_to include('href="/account"')
+    expect(about.body).to include('<h4><em>account</em></h4>', 'href="/api-keys"')
   end
 
   it 'always requires an API key independently of browser authentication' do
@@ -535,54 +538,81 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     expect(request.get('/api/missing').status).to eq(404)
     expect(request.get('/api/stats').status).to eq(401)
     expect(request.get('/api-docs').status).to eq(200)
-    expect(request.get('/api-keys').status).to eq(404)
+    api_keys = request.get('/api-keys')
+    expect(api_keys.status).to eq(200)
+    expect(api_keys['cache-control']).to include('no-store')
     expect(request.get('/apiculture').status).to eq(404)
   end
 
-  it 'consolidates API documentation and key management behind web authentication' do
+  it 'protects API documentation and key management with browser authentication' do
     create_account
     client = ApplicationSessionClient.new(app)
 
-    response = client.get('/api-docs')
-    expect(response.status).to eq(302)
-    expect(redirect_path(response)).to eq('/login')
+    ['/api-docs', '/api-keys'].each do |path|
+      response = client.get(path)
+      expect(response.status).to eq(302)
+      expect(redirect_path(response)).to eq('/login')
+    end
+  end
 
+  it 'renders API documentation without embedded key-management controls or endpoint links' do
+    create_account
+    client = ApplicationSessionClient.new(app)
     login(client)
     issued_key = ApiKey.issue('existing client')
-    response = client.get('/api-docs')
+    docs_page = client.get('/api-docs')
 
-    expect(response.status).to eq(200)
-    expect(response.body).to include(
-      'endpoints', '/api/health', 'api keys', 'action="/api-docs/keys"', issued_key.api_key.token_prefix
+    expect(docs_page.body).to include(
+      'api reference', '/api/health', 'Authorization: Bearer &lt;api-key&gt;', 'href="/api-keys"',
+      'POST</strong> <code>/api/tools/pubkey</code>', 'GET</strong> <code>/api/tools/pubkey</code>',
+      'deprecated', 'protonvpn', 'opnsense', 'qbittorrent', 'wireguard', 'ruby'
     )
-    endpoints_position = response.body.index('<h4><em>api endpoints</em></h4>')
-    keys_position = response.body.index('<h4><em>api keys</em></h4>')
-    expect(endpoints_position).to be < keys_position
-    expect(response.body.scan('href="/api-docs">api</a>').length).to eq(1)
-    expect(response.body).not_to include('href="/api-keys"', '>keys</a>')
-    expect(response.body).to include('<code>Authorization: Bearer qbop_...</code>')
-    expect(response.body).to include('including <code>/api/health</code>', 'http basic auth is not supported')
-    expect(response.body).to include(
-      'POST /api/tools/pubkey', 'YOUR_WIREGUARD_PRIVATE_KEY',
-      'GET /api/tools/pubkey is deprecated'
+    expect(docs_page.body).not_to include(
+      'action="/api-keys"', 'action="/api-docs/keys"',
+      issued_key.api_key.token_prefix, '<legend>create api key</legend>', '>revoke</button>',
+      'ProtonVPN', 'OPNsense', 'qBittorrent', 'WireGuard', 'Ruby'
     )
-    expect(response.body).not_to include('/pubkey?private-key=')
-    expect(response.body).not_to match(%r{<code[^>]*>`|`</code>})
+    expect(docs_page.body).not_to match(%r{href="/api(?:/|")})
+    documented_endpoints = {
+      'GET' => %w[/api/stats /api/health /api/notifications /api/about /api/logs /api/history
+                  /api/tools/pubkey /api/tools/public-ip /api/tools/wireguard-targets],
+      'POST' => %w[/api/tools/pubkey /api/tools/wireguard-import]
+    }
+    documented_endpoints.each do |method, paths|
+      paths.each { |path| expect(docs_page.body).to include("<strong>#{method}</strong> <code>#{path}</code>") }
+    end
+    expect(docs_page.body.scan(%r{</fieldset>\s*<br>}).length).to eq(9)
+  end
+
+  it 'renders API key management without adding it to the primary navigation' do
+    create_account
+    client = ApplicationSessionClient.new(app)
+    login(client)
+    issued_key = ApiKey.issue('existing client')
+    keys_page = client.get('/api-keys')
+
+    expect(keys_page.status).to eq(200)
+    expect(keys_page['cache-control']).to include('no-store')
+    expect(keys_page.body).to include(
+      '<h4><em>api keys</em></h4>', 'action="/api-keys"', issued_key.api_key.token_prefix
+    )
+    expect(keys_page.body.scan('href="/api-keys"').length).to eq(0)
+    expect(keys_page.body.scan('href="/api-docs">api docs</a>').length).to eq(1)
   end
 
   it 'creates an API key with CSRF and displays its secret exactly once' do
     create_account
     client = ApplicationSessionClient.new(app)
     login(client)
-    page = client.get('/api-docs')
+    page = client.get('/api-keys')
 
-    expect(client.post('/api-docs/keys', name: 'home assistant').status).to eq(403)
+    expect(client.post('/api-keys', name: 'home assistant').status).to eq(403)
     expect(ApiKey.count).to eq(0)
 
-    creation_path = '/api-docs/keys'
+    creation_path = '/api-keys'
     creation = client.post(creation_path, name: 'home assistant', _csrf: csrf_token_for(page, creation_path))
     expect(creation.status).to eq(303)
-    expect(redirect_path(creation)).to eq('/api-docs')
+    expect(redirect_path(creation)).to eq('/api-keys')
 
     secret_page = client.get(redirect_path(creation))
     token = secret_page.body[/qbop_[0-9a-f]{64}/]
@@ -597,7 +627,7 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     expect(api_key.values.values).not_to include(token)
     expect(creation['set-cookie']).not_to include(token)
 
-    later_page = client.get('/api-docs')
+    later_page = client.get('/api-keys')
     expect(later_page.body).to include("#{api_key.token_prefix}...")
     expect(later_page.body).not_to include(token)
   end
@@ -605,8 +635,8 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
   it 'rejects empty names and escapes key names in the list' do
     ENV['WEB_AUTH_ENABLED'] = 'false'
     client = ApplicationSessionClient.new(app)
-    page = client.get('/api-docs')
-    creation_path = '/api-docs/keys'
+    page = client.get('/api-keys')
+    creation_path = '/api-keys'
     response = client.post(creation_path, name: '   ', _csrf: csrf_token_for(page, creation_path))
     error_page = client.get(redirect_path(response))
 
@@ -626,8 +656,8 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     client = ApplicationSessionClient.new(app)
     first = ApiKey.issue('first client')
     second = ApiKey.issue('second client')
-    page = client.get('/api-docs')
-    delete_path = "/api-docs/keys/#{first.api_key.id}/delete"
+    page = client.get('/api-keys')
+    delete_path = "/api-keys/#{first.api_key.id}/delete"
 
     expect(client.get(delete_path).status).to eq(404)
     expect(client.post(delete_path).status).to eq(403)
@@ -637,21 +667,21 @@ RSpec.describe Framework::Application do # rubocop:disable Metrics/BlockLength
     request = Rack::MockRequest.new(app)
 
     expect(response.status).to eq(303)
-    expect(redirect_path(response)).to eq('/api-docs')
+    expect(redirect_path(response)).to eq('/api-keys')
     expect(ApiKey[first.api_key.id]).to be_nil
     expect(ApiKey[second.api_key.id]).not_to be_nil
-    expect(client.get('/api-docs').body).not_to include('first client')
+    expect(client.get('/api-keys').body).not_to include('first client')
     expect(request.get('/api/stats', bearer_auth(first.token)).status).to eq(401)
     expect(request.get('/api/stats', bearer_auth(second.token)).status).to eq(200)
   end
 
-  it 'does not expose the former API-key page or mutation routes' do
+  it 'does not expose the old API Docs key-management routes' do
     ENV['WEB_AUTH_ENABLED'] = 'false'
     request = Rack::MockRequest.new(app)
 
-    expect(request.get('/api-keys').status).to eq(404)
-    expect(request.post('/api-keys').status).to eq(404)
-    expect(request.post('/api-keys/1/delete').status).to eq(404)
+    expect(request.get('/api-docs/keys').status).to eq(404)
+    expect(request.post('/api-docs/keys').status).to eq(404)
+    expect(request.post('/api-docs/keys/1/delete').status).to eq(404)
   end
 
   it 'does not expose the former authentication routes' do

--- a/spec/framework/oidc_authentication_spec.rb
+++ b/spec/framework/oidc_authentication_spec.rb
@@ -719,7 +719,7 @@ RSpec.describe 'OpenID Connect browser authentication' do # rubocop:disable Metr
       "document.getElementById('oidc-login-form').submit()", OIDC_SPEC_CLIENT_SECRET
     )
     expect(logged_out_page.status).to eq(200)
-    expect(logged_out_page.body).to include('You have been logged out.')
+    expect(logged_out_page.body).to include('you have been logged out.')
     expect(logged_out_page.body).not_to include("document.getElementById('oidc-login-form').submit()")
 
     SpecDatabase.reset!

--- a/spec/framework/web_spec.rb
+++ b/spec/framework/web_spec.rb
@@ -141,14 +141,14 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
     expect(response.body).to include(
       'id="wireguardrenamepeer"',
       'rename peer to match new proton server',
-      "Uses proton's server identifier to generate a name such as",
+      "uses proton's server identifier to generate a name such as",
       '<code>Proton_US-IL661</code>'
     )
     checkbox = response.body[/<input[^>]+id="wireguardrenamepeer"[^>]*>/]
     expect(checkbox).not_to include('disabled', 'checked')
     expect(response.body).not_to include(
       'protonPeerName', 'FileReader', 'wireguardrenamepeerlabel',
-      'reload Tools to use the WireGuard importer'
+      'reload tools to use the wireguard importer'
     )
   end
 
@@ -160,12 +160,12 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(200)
     expect(response.body).to include(
-      'Proton WireGuard import requires OPNsense integration.',
+      'proton wireguard import requires opnsense integration.',
       'generate wireguard public key',
       'get public ip address'
     )
     expect(response.body).not_to include('id="wgimportform"')
-    expect(response.body).not_to include('reload Tools to use the WireGuard importer')
+    expect(response.body).not_to include('reload tools to use the wireguard importer')
   end
 
   it 'does not process a WireGuard import when OPNsense is skipped' do
@@ -180,7 +180,7 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
     )
 
     expect(response.status).to eq(200)
-    expect(response.body).to include('Proton WireGuard import requires OPNsense integration.')
+    expect(response.body).to include('proton wireguard import requires opnsense integration.')
     expect(response.body).not_to include('distinctive-skipped-private-config-value')
   end
 
@@ -198,7 +198,7 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
       'get public ip address'
     )
     expect(response.body).not_to include('id="wgimportform"')
-    expect(response.body).not_to include('reload Tools to use the WireGuard importer')
+    expect(response.body).not_to include('reload tools to use the wireguard importer')
   end
 
   it 'updates the selected OPNsense WireGuard instance and peer synchronously' do # rubocop:disable Metrics/BlockLength
@@ -341,7 +341,7 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(200)
     expect(response.body).to include('public-key')
-    expect(response.body).to include('href="/tools">reload Tools to use the WireGuard importer</a>')
+    expect(response.body).to include('href="/tools">reload tools to use the wireguard importer</a>')
     expect(response.body).not_to include('could not load OPNsense WireGuard targets')
   end
 
@@ -356,12 +356,12 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
 
     expect(public_key_response.status).to eq(200)
     expect(public_key_response.body).to include('public-key')
-    expect(public_key_response.body).to include('Proton WireGuard import requires OPNsense integration.')
-    expect(public_key_response.body).not_to include('reload Tools to use the WireGuard importer')
+    expect(public_key_response.body).to include('proton wireguard import requires opnsense integration.')
+    expect(public_key_response.body).not_to include('reload tools to use the wireguard importer')
     expect(public_ip_response.status).to eq(200)
     expect(public_ip_response.body).to include('akamai -> 192.0.2.1')
-    expect(public_ip_response.body).to include('Proton WireGuard import requires OPNsense integration.')
-    expect(public_ip_response.body).not_to include('reload Tools to use the WireGuard importer')
+    expect(public_ip_response.body).to include('proton wireguard import requires opnsense integration.')
+    expect(public_ip_response.body).not_to include('reload tools to use the wireguard importer')
   end
 
   it 'renders public IP tool results without loading WireGuard targets' do
@@ -372,7 +372,7 @@ RSpec.describe Framework::Web do # rubocop:disable Metrics/BlockLength
 
     expect(response.status).to eq(200)
     expect(response.body).to include('akamai -> 192.0.2.1')
-    expect(response.body).to include('href="/tools">reload Tools to use the WireGuard importer</a>')
+    expect(response.body).to include('href="/tools">reload tools to use the wireguard importer</a>')
     expect(response.body).not_to include('could not load OPNsense WireGuard targets')
   end
 

--- a/spec/service/opnsense_spec.rb
+++ b/spec/service/opnsense_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe Service::Opnsense do # rubocop:disable Metrics/BlockLength
     )
   end
 
+  it 'uses lowercase product names in missing-configuration errors' do
+    missing_config = config.merge(
+      opnsense_interface_addr: nil,
+      opnsense_api_key: nil,
+      opnsense_api_secret: nil
+    )
+
+    expect { described_class.new(missing_config).validate_wireguard_config }
+      .to raise_error(
+        described_class::WireguardImportError,
+        'missing opnsense configuration: OPN_INTERFACE_ADDR, OPN_API_KEY, OPN_API_SECRET'
+      )
+  end
+
   it 'returns an alias UUID' do
     response = instance_double(Faraday::Response, body: '{"uuid":"alias-uuid"}')
 

--- a/spec/service/proton_wireguard_rotation_spec.rb
+++ b/spec/service/proton_wireguard_rotation_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe Service::ProtonWireguardRotation do # rubocop:disable Metrics/Blo
 
     expect do
       rotation_for(opnsense).rotate(wireguard, instance_uuid: 'new', peer_uuid: peer_uuid)
-    end.to raise_error(described_class::Error, /Instance selection is invalid/)
+    end.to raise_error(described_class::Error, /instance selection is invalid/)
   end
 
   it 'rejects an invalid generated peer name before contacting OPNsense' do
@@ -352,7 +352,7 @@ RSpec.describe Service::ProtonWireguardRotation do # rubocop:disable Metrics/Blo
         peer_uuid: peer_uuid,
         rename_peer: true
       )
-    end.to raise_error(described_class::Error, /generated name is not valid for OPNsense/)
+    end.to raise_error(described_class::Error, /generated name is not valid for opnsense/)
   end
 
   it 'rejects a disabled instance before writing' do
@@ -376,7 +376,7 @@ RSpec.describe Service::ProtonWireguardRotation do # rubocop:disable Metrics/Blo
 
     expect do
       rotation_for(opnsense).rotate(wireguard, instance_uuid: instance_uuid, peer_uuid: peer_uuid)
-    end.to raise_error(described_class::Error, /Peer proton-peer must be enabled before import/)
+    end.to raise_error(described_class::Error, /peer proton-peer must be enabled before import/)
   end
 
   it 'rejects a peer shared with another instance before mutation' do

--- a/spec/service/proton_wireguard_spec.rb
+++ b/spec/service/proton_wireguard_spec.rb
@@ -120,10 +120,10 @@ RSpec.describe Service::ProtonWireguard do # rubocop:disable Metrics/BlockLength
 
   it 'continues validating every consumed WireGuard setting' do
     invalid_settings = {
-      config.sub(private_key, 'invalid') => /Interface private key is not a valid WireGuard key/,
+      config.sub(private_key, 'invalid') => /Interface private key is not a valid wireguard key/,
       config.sub('Address = 10.2.0.2/32, 2a07:b944::2:2/128', 'Address = invalid') =>
         /Interface address is invalid/,
-      config.sub(peer_public_key, 'invalid') => /Peer public key is not a valid WireGuard key/,
+      config.sub(peer_public_key, 'invalid') => /Peer public key is not a valid wireguard key/,
       config.sub('AllowedIPs = 0.0.0.0/0, ::/0', 'AllowedIPs = invalid') =>
         /Peer allowed IPs is invalid/,
       config.sub('Endpoint = 192.0.2.10:51820', 'Endpoint = invalid') =>
@@ -146,7 +146,7 @@ RSpec.describe Service::ProtonWireguard do # rubocop:disable Metrics/BlockLength
       expect { described_class.new(helpers).import(duplicate_peer) }
         .to raise_error(described_class::ImportError, /exactly one \[Peer\] section/)
       expect { described_class.new(helpers).import(unsupported_section) }
-        .to raise_error(described_class::ImportError, /unsupported WireGuard section \[Unknown\]/)
+        .to raise_error(described_class::ImportError, /unsupported wireguard section \[Unknown\]/)
     end
   end
 
@@ -185,7 +185,7 @@ RSpec.describe Service::ProtonWireguard do # rubocop:disable Metrics/BlockLength
     identifier = "#{'A' * 57}#1"
 
     expect { described_class.peer_name_for(identifier) }
-      .to raise_error(described_class::ImportError, /not valid for OPNsense/)
+      .to raise_error(described_class::ImportError, /not valid for opnsense/)
   end
 
   it 'rejects a config that does not declare NAT-PMP status' do

--- a/views/_nav.erb
+++ b/views/_nav.erb
@@ -1,4 +1,4 @@
-<% nav_items = [['stats', '/'], ['history', '/history'], ['api', '/api-docs'], ['tools', '/tools'], ['logs', '/logs'], ['about', '/about']] %>
+<% nav_items = [['stats', '/'], ['history', '/history'], ['tools', '/tools'], ['logs', '/logs'], ['api docs', '/api-docs'], ['about', '/about']] %>
 <div class="terminal-nav">
   <div class="terminal-logo">
     <div class="logo terminal-prompt"><a href="/" class="no-style">qbop</a></div>

--- a/views/about.erb
+++ b/views/about.erb
@@ -53,13 +53,15 @@
 </blockquote>
 <hr>
 
-<% if @web_auth_enabled %>
 <h4><em>account</em></h4>
 <blockquote>
+  <% if @web_auth_enabled %>
   <a href="/account">manage email and password</a>
+  <br>
+  <% end %>
+  <a href="/api-keys">create and manage api keys</a>
 </blockquote>
 <hr>
-<% end %>
 
 <h4><em>env variables</em></h4>
 <blockquote>

--- a/views/api_docs.erb
+++ b/views/api_docs.erb
@@ -1,132 +1,221 @@
-<%= erb :_nav, locals: { active: 'api' }, layout: false %>
+<%= erb :_nav, locals: { active: 'api docs' }, layout: false %>
 <% if @update_available %>
 <div class="terminal-alert terminal-alert-primary"><a href="https://github.com/clajiness/qbop/releases" target="_blank">an update is available:</a> <a href="https://github.com/clajiness/qbop/releases/tag/<%= @recent_tag %>" target="_blank"><%= @recent_tag %></a></div>
 <% end %>
 <hr>
 
 <section>
-  <h4><em>api endpoints</em></h4>
-
-  <ul>
-    <li>GET <a class="menu-item" href="/api/stats" target="_blank">/api/stats</a></li>
-    <li>
-      GET /api/tools
-      <ul>
-        <li><a class="menu-item" href="/api/tools/wireguard-targets" target="_blank">/wireguard-targets</a> (returns 503 when OPN_SKIP=true)</li>
-        <li>
-          POST /api/tools/wireguard-import
-          <ul>
-            <li>config: protonvpn wireguard configuration text</li>
-            <li>instance_uuid: selected opnsense instance uuid</li>
-            <li>peer_uuid: selected opnsense peer uuid</li>
-            <li>rename_peer: optional boolean; when true, rename the peer from a valid proton server comment in the configuration (the request fails if no valid server name is present)</li>
-            <li>updates proton wireguard credentials, tunnel addresses within the adopted tunnel's existing address-family policy, peer endpoint/allowed ips, and optionally the peer name; preserves opnsense-local dns, gateway, routing, firewall, nat, and interface settings</li>
-            <li>the enabled instance and peer must be dedicated to each other; qbop disables and applies the instance, verifies it is absent from wireguard runtime state, saves the peer and instance, applies while disabled, then re-enables, applies, and verifies the imported instance and peer keys</li>
-            <li>returns the completed instance and peer names after a successful rotation</li>
-            <li>returns 409 if another wireguard rotation is already in progress</li>
-            <li>returns 503 without parsing or rotating the configuration when OPN_SKIP=true</li>
-          </ul>
-        </li>
-        <li>
-          POST /api/tools/pubkey
-          <ul>
-            <li>JSON body: private_key: <code>YOUR_WIREGUARD_PRIVATE_KEY</code></li>
-            <li>returns the derived public_key</li>
-            <li>GET /api/tools/pubkey is deprecated; its private-key query parameter remains available only for compatibility</li>
-          </ul>
-        </li>
-        <li>
-          /public-ip
-          <ul>
-            <li><a class="menu-item" href="/api/tools/public-ip?service=akamai" target="_blank">?service=akamai</a></li>
-            <li><a class="menu-item" href="/api/tools/public-ip?service=cloudflare" target="_blank">?service=cloudflare</a></li>
-            <li><a class="menu-item" href="/api/tools/public-ip?service=google" target="_blank">?service=google</a></li>
-            <li><a class="menu-item" href="/api/tools/public-ip?service=opendns" target="_blank">?service=opendns</a></li>
-          </ul>
-        </li>
-      </ul>
-    </li>
-    <li>GET <a class="menu-item" href="/api/logs" target="_blank">/api/logs</a></li>
-    <li>GET <a class="menu-item" href="/api/history?page=1&per_page=25" target="_blank">/api/history?page=1&amp;per_page=25</a></li>
-    <li>GET <a class="menu-item" href="/api/about" target="_blank">/api/about</a></li>
-    <li>GET <a class="menu-item" href="/api/health" target="_blank">/api/health</a></li>
-    <li>GET <a class="menu-item" href="/api/notifications" target="_blank">/api/notifications</a></li>
-  </ul>
-
-  <br>
+  <h4><em>api reference</em></h4>
+  <p>qbop exposes a JSON api for status, history, logs, and selected tools.</p>
 
   <fieldset>
     <legend>authentication</legend>
-    <p>all api requests require an api key, including <code>/api/health</code>.</p>
-    <p>inbound http basic auth is not supported.</p>
-    <p>send the key in the authorization header:</p>
-    <p><code>Authorization: Bearer qbop_...</code></p>
-    <p>create and revoke api keys below. new keys are shown only once.</p>
+    <p>every api request requires a qbop api key, including <code>/api/health</code>. browser sessions and http basic authentication are not accepted.</p>
+    <p>send the key with the bearer authentication scheme:</p>
+    <pre><code>Authorization: Bearer &lt;api-key&gt;</code></pre>
+    <p><a href="/api-keys">create and manage api keys</a></p>
+  </fieldset>
+  <br>
+
+  <p>set <code>QBOP_URL</code> to the qbop origin and <code>QBOP_API_KEY</code> to a complete <code>qbop_...</code> secret before using the examples. responses are JSON. a missing, malformed, or revoked key returns <code>401</code> with <code>{"error":"unauthorized"}</code>.</p>
+</section>
+
+<hr>
+
+<section class="api-reference">
+  <h4><em>status and information</em></h4>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/stats</code></legend>
+    <p>returns current port, connection state, check/change times, and longest time on the same port for protonvpn, opnsense, and qbittorrent.</p>
+    <p><strong>parameters:</strong> none</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/stats"</code></pre>
+    <pre><code>{
+  "stats": {
+    "protonvpn": {
+      "current_port": 51820,
+      "last_changed": "2026-08-31 12:00:00 +0000",
+      "last_checked": "2026-08-31 12:01:00 +0000",
+      "delta": 60,
+      "connected": true
+    }
+  },
+  "records": {"longest_time_on_same_port": {"proton": 3600, "opnsense": 3600, "qbit": 3600}}
+}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
+  </fieldset>
+  <br>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/health</code></legend>
+    <p>returns an http status for each integration. disabled opnsense or qbittorrent integrations are reported as <code>"skipped"</code>.</p>
+    <p><strong>parameters:</strong> none</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/health"</code></pre>
+    <pre><code>{"health":{"protonvpn":200,"opnsense":200,"qbit":"skipped"}}</code></pre>
+    <p><strong>status:</strong> <code>200</code> when all enabled services are healthy, <code>503</code> when any enabled service is stale, <code>401</code></p>
+  </fieldset>
+  <br>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/notifications</code></legend>
+    <p>returns the current update-available notification and its active state.</p>
+    <p><strong>parameters:</strong> none</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/notifications"</code></pre>
+    <pre><code>{"notifications":{"name":"update_available","info":"v3.1.0","active":true}}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
+  </fieldset>
+  <br>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/about</code></legend>
+    <p>returns build, schema, ruby, uptime, and non-secret configuration information. configured credentials are masked.</p>
+    <p><strong>parameters:</strong> none</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/about"</code></pre>
+    <pre><code>{
+  "about": {"app_version":"v3.0.0","commit_sha":"...","schema_version":7,"uptime":3600},
+  "env_variables": {"opn_api_key":"***","opn_api_secret":"***","qbit_pass":"***"}
+}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
   </fieldset>
 </section>
 
 <hr>
 
-<section>
-  <h4><em>api keys</em></h4>
-  <p>create and revoke credentials used to access the api.</p>
+<section class="api-reference">
+  <h4><em>activity</em></h4>
 
-  <% if @new_api_key %>
-  <div class="terminal-alert terminal-alert-primary">
-    copy this api key now. it will not be shown again.<br>
-    <code><%= @new_api_key %></code>
-  </div>
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/logs</code></legend>
+    <p>returns qbop log lines without their trailing newline characters.</p>
+    <ul>
+      <li><code>lines</code> — optional positive integer, clamped to 1–5000; defaults to <code>LOG_LINES</code>.</li>
+      <li><code>direction</code> — optional <code>asc</code> or <code>desc</code>; defaults from <code>LOG_REVERSE</code>.</li>
+    </ul>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/logs?lines=100&amp;direction=desc"</code></pre>
+    <pre><code>{"log_lines":["newest line","older line"]}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
+  </fieldset>
   <br>
-  <% end %>
 
-  <% if @api_key_error %>
-  <div class="terminal-alert terminal-alert-error"><%= Rack::Utils.escape_html(@api_key_error) %></div>
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/history</code></legend>
+    <p>returns port transitions in reverse chronological order with opnsense and qbittorrent synchronization status.</p>
+    <ul>
+      <li><code>page</code> — optional positive integer; defaults to <code>1</code>.</li>
+      <li><code>per_page</code> — optional <code>25</code>, <code>50</code>, or <code>100</code>; defaults to <code>25</code>.</li>
+    </ul>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/history?page=1&amp;per_page=25"</code></pre>
+    <pre><code>{
+  "history": [{
+    "id": 42,
+    "previous_port": 51820,
+    "new_port": 51821,
+    "detected_at": "2026-08-31 12:00:00 +0000",
+    "opnsense": {"status":"synced","synced_at":"2026-08-31 12:00:01 +0000"},
+    "qbit": {"status":"synced","synced_at":"2026-08-31 12:00:02 +0000"}
+  }],
+  "pagination": {"total_records":1,"current_page":1,"per_page":25,"total_pages":1,"from":1,"to":1}
+}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
+  </fieldset>
+</section>
+
+<hr>
+
+<section class="api-reference">
+  <h4><em>tools</em></h4>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>POST</strong> <code>/api/tools/pubkey</code></legend>
+    <p>derives a wireguard public key from a private key supplied in the JSON request body. the private key must be a base64-encoded 32-byte wireguard key.</p>
+    <p><strong>JSON body:</strong> required string <code>private_key</code>. it is deliberately rejected if supplied in the query string.</p>
+    <pre><code>curl --fail-with-body \
+  -X POST \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"private_key":"BASE64_WIREGUARD_PRIVATE_KEY"}' \
+  "$QBOP_URL/api/tools/pubkey"</code></pre>
+    <pre><code>{"public_key":"BASE64_WIREGUARD_PUBLIC_KEY"}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code>, <code>422</code> for a missing, malformed, or unusable key</p>
+  </fieldset>
   <br>
-  <% end %>
 
-  <form action="/api-docs/keys" method="post">
-    <fieldset>
-      <legend>create api key</legend>
-      <%= request.env.fetch('rodauth').csrf_tag('/api-docs/keys') %>
-      <div class="form-group">
-        <label for="name">name</label>
-        <input id="name" name="name" type="text" maxlength="<%= ApiKey::MAX_NAME_LENGTH %>" autocomplete="off" required>
-      </div>
-      <div class="form-group">
-        <button class="btn btn-default btn-ghost" type="submit">generate</button>
-      </div>
-    </fieldset>
-  </form>
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/tools/pubkey</code> — deprecated</legend>
+    <p>compatibility endpoint that accepts the wireguard private key in the <code>private-key</code> query parameter. use the POST endpoint so private key material is sent in the request body.</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  --get --data-urlencode "private-key=BASE64_WIREGUARD_PRIVATE_KEY" \
+  "$QBOP_URL/api/tools/pubkey"</code></pre>
+    <pre><code>{"public_key":"BASE64_WIREGUARD_PUBLIC_KEY"}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code></p>
+  </fieldset>
+  <br>
 
-  <% if @api_keys.empty? %>
-  <blockquote>no api keys have been created yet</blockquote>
-  <% else %>
-  <table>
-    <thead>
-      <tr>
-        <th>name</th>
-        <th>key</th>
-        <th>created</th>
-        <th>last used</th>
-        <th>action</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @api_keys.each do |api_key| %>
-      <tr>
-        <td><%= Rack::Utils.escape_html(api_key.name) %></td>
-        <td><code><%= api_key.token_prefix %>...</code></td>
-        <td><%= api_key.created_at %></td>
-        <td><%= api_key.last_used_at || 'never' %></td>
-        <td>
-          <form action="/api-docs/keys/<%= api_key.id %>/delete" method="post">
-            <%= request.env.fetch('rodauth').csrf_tag("/api-docs/keys/#{api_key.id}/delete") %>
-            <button class="btn btn-default btn-ghost" type="submit">revoke</button>
-          </form>
-        </td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
-  <% end %>
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/tools/public-ip</code></legend>
+    <p>looks up the public IP address through a selected DNS provider.</p>
+    <p><strong>query parameter:</strong> <code>service</code> — <code>akamai</code>, <code>cloudflare</code>, <code>google</code>, or <code>opendns</code>.</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/tools/public-ip?service=cloudflare"</code></pre>
+    <pre><code>{"service":"cloudflare","public_ip":"203.0.113.10"}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code>. an unsupported provider is described in the <code>public_ip</code> value.</p>
+  </fieldset>
+  <br>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>GET</strong> <code>/api/tools/wireguard-targets</code></legend>
+    <p>returns eligible opnsense wireguard instances and peers for use with the import endpoint.</p>
+    <p><strong>parameters:</strong> none</p>
+    <pre><code>curl --fail-with-body \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  "$QBOP_URL/api/tools/wireguard-targets"</code></pre>
+    <pre><code>{
+  "wireguard_targets": {
+    "instances": [{"uuid":"...","name":"proton-instance","interface":"wg0"}],
+    "peers": [{"uuid":"...","name":"proton-peer"}]
+  }
+}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code>, <code>422</code> if targets cannot be loaded, <code>503</code> when <code>OPN_SKIP=true</code></p>
+  </fieldset>
+  <br>
+
+  <fieldset class="api-endpoint">
+    <legend><strong>POST</strong> <code>/api/tools/wireguard-import</code></legend>
+    <p>imports a protonvpn wireguard configuration into a dedicated, enabled opnsense instance and peer. the rotation is synchronous and preserves opnsense-local DNS, gateway, routing, firewall, NAT, and interface settings.</p>
+    <ul>
+      <li><code>config</code> — required protonvpn wireguard configuration text, at most 16 KiB.</li>
+      <li><code>instance_uuid</code> — required UUID from <code>/api/tools/wireguard-targets</code>.</li>
+      <li><code>peer_uuid</code> — required UUID from <code>/api/tools/wireguard-targets</code>.</li>
+      <li><code>rename_peer</code> — optional boolean; when true, renames the peer from a valid proton server comment.</li>
+    </ul>
+    <pre><code>curl --fail-with-body \
+  -X POST \
+  -H "Authorization: Bearer $QBOP_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data-binary @- \
+  "$QBOP_URL/api/tools/wireguard-import" &lt;&lt;'JSON'
+{
+  "config": "[Interface]\nPrivateKey = ...\n...",
+  "instance_uuid": "11111111-1111-4111-8111-111111111111",
+  "peer_uuid": "22222222-2222-4222-8222-222222222222",
+  "rename_peer": false
+}
+JSON</code></pre>
+    <pre><code>{"wireguard_import":{"instance_name":"proton-instance","peer_name":"proton-peer"}}</code></pre>
+    <p><strong>status:</strong> <code>200</code>, <code>401</code>, <code>409</code> if another rotation is running, <code>422</code> for invalid input or a failed rotation, <code>503</code> when <code>OPN_SKIP=true</code></p>
+  </fieldset>
 </section>

--- a/views/api_keys.erb
+++ b/views/api_keys.erb
@@ -1,0 +1,72 @@
+<%= erb :_nav, locals: { active: 'api docs' }, layout: false %>
+<% if @update_available %>
+<div class="terminal-alert terminal-alert-primary"><a href="https://github.com/clajiness/qbop/releases" target="_blank">an update is available:</a> <a href="https://github.com/clajiness/qbop/releases/tag/<%= @recent_tag %>" target="_blank"><%= @recent_tag %></a></div>
+<% end %>
+<hr>
+
+<section>
+  <h4><em>api keys</em></h4>
+  <p>create and revoke credentials used to access the <a href="/api-docs">qbop api</a>.</p>
+  <p>new secrets are shown only once. create a replacement before revoking a key used by an existing client.</p>
+
+  <% if @new_api_key %>
+  <div class="terminal-alert terminal-alert-primary">
+    copy this api key now. it will not be shown again.<br>
+    <code><%= @new_api_key %></code>
+  </div>
+  <br>
+  <% end %>
+
+  <% if @api_key_error %>
+  <div class="terminal-alert terminal-alert-error"><%= Rack::Utils.escape_html(@api_key_error) %></div>
+  <br>
+  <% end %>
+
+  <form action="/api-keys" method="post">
+    <fieldset>
+      <legend>create api key</legend>
+      <%= request.env.fetch('rodauth').csrf_tag('/api-keys') %>
+      <div class="form-group">
+        <label for="name">name</label>
+        <input id="name" name="name" type="text" maxlength="<%= ApiKey::MAX_NAME_LENGTH %>" autocomplete="off" required>
+      </div>
+      <div class="form-group">
+        <button class="btn btn-default btn-ghost" type="submit">generate</button>
+      </div>
+    </fieldset>
+  </form>
+
+  <% if @api_keys.empty? %>
+  <blockquote>no api keys have been created yet</blockquote>
+  <% else %>
+  <div class="api-key-table-wrapper">
+    <table class="api-key-table">
+      <thead>
+        <tr>
+          <th>name</th>
+          <th>key</th>
+          <th>created</th>
+          <th>last used</th>
+          <th>action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @api_keys.each do |api_key| %>
+        <tr>
+          <td><%= Rack::Utils.escape_html(api_key.name) %></td>
+          <td><code><%= api_key.token_prefix %>...</code></td>
+          <td><%= api_key.created_at %></td>
+          <td><%= api_key.last_used_at || 'never' %></td>
+          <td>
+            <form action="/api-keys/<%= api_key.id %>/delete" method="post">
+              <%= request.env.fetch('rodauth').csrf_tag("/api-keys/#{api_key.id}/delete") %>
+              <button class="btn btn-default btn-ghost" type="submit">revoke</button>
+            </form>
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <% end %>
+</section>

--- a/views/logged_out.erb
+++ b/views/logged_out.erb
@@ -2,7 +2,7 @@
   <div class="logo terminal-prompt"><a href="/" class="no-style">qbop</a></div>
   <fieldset>
     <legend>oidc logout</legend>
-    <p>You have been logged out.</p>
+    <p>you have been logged out.</p>
     <p><a class="btn btn-default" href="/login">sign in</a></p>
   </fieldset>
 </section>

--- a/views/tools.erb
+++ b/views/tools.erb
@@ -7,7 +7,7 @@
 <div class="terminal-card">
   <header>import protonvpn wireguard config</header>
   <div>
-    upload or paste a protonvpn wireguard configuration to update a dedicated opnsense instance and peer. qbop changes only proton-managed wireguard fields and preserves opnsense-local settings and associations. The configuration is never logged, persisted by qbop, or returned.
+    upload or paste a protonvpn wireguard configuration to update a dedicated opnsense instance and peer. qbop changes only proton-managed wireguard fields and preserves opnsense-local settings and associations. the configuration is never logged, persisted by qbop, or returned.
   </div>
 </div>
 <br>
@@ -17,7 +17,7 @@
 <% elsif @wireguard_targets_error %>
 <div class="terminal-alert terminal-alert-error" role="alert"><%= Rack::Utils.escape_html(@wireguard_targets_error) %></div>
 <% elsif @wireguard_targets_not_loaded %>
-<div role="status"><a class="btn btn-default btn-ghost" href="/tools">reload Tools to use the WireGuard importer</a></div>
+<div role="status"><a class="btn btn-default btn-ghost" href="/tools">reload tools to use the wireguard importer</a></div>
 <% else %>
 <form action="/wireguard-import" method="post" enctype="multipart/form-data" id="wgimportform">
   <fieldset>
@@ -52,7 +52,7 @@
       <textarea id="wireguardconfig" name="wireguardconfig" rows="12" placeholder="[Interface] ..." autocomplete="off" autocapitalize="off" spellcheck="false"></textarea>
     </div>
     <div class="form-group">
-      <label for="wireguardrenamepeer"><input id="wireguardrenamepeer" name="wireguardrenamepeer" type="checkbox" value="true"/> rename peer to match new proton server. Uses proton's server identifier to generate a name such as <code>Proton_US-IL661</code>.</label>
+      <label for="wireguardrenamepeer"><input id="wireguardrenamepeer" name="wireguardrenamepeer" type="checkbox" value="true"/> rename peer to match new proton server. uses proton's server identifier to generate a name such as <code>Proton_US-IL661</code>.</label>
     </div>
     <div class="form-group">
       <input id="wireguardresult" name="wireguardresult" type="text" value="<%= Rack::Utils.escape_html(@wireguard_result) %>" placeholder="import result" readonly/>


### PR DESCRIPTION
Separate API key management from the API reference by adding a dedicated /api-keys page and view (views/api_keys.erb). Update web routes, forms, nav label (api -> api docs), and redirects to use /api-keys. Expand CSS to support key table layout. Revise README links and API docs to point to /api-keys and clarify api reference. Normalize product/name casing in messages and errors (opnsense, wireguard, protonvpn) across services, framework, views, and specs and update tests to match. Adjust specs to reflect the new routes and content.